### PR TITLE
fix: regexp for image with title

### DIFF
--- a/integration-test/tests/editor.spec.ts
+++ b/integration-test/tests/editor.spec.ts
@@ -98,6 +98,14 @@ test.describe('input:', () => {
             expect(image).toBeDefined();
         });
 
+        test('image with title', async ({ page }) => {
+            const editor = await page.waitForSelector('.editor');
+
+            await editor.type('![image](url "title")');
+            const image = await editor.waitForSelector('.image');
+            expect(image).toBeDefined();
+        });
+
         test('code block', async ({ page }) => {
             const editor = await page.waitForSelector('.editor');
 

--- a/packages/preset-commonmark/src/node/image.ts
+++ b/packages/preset-commonmark/src/node/image.ts
@@ -212,7 +212,7 @@ export const image = createNode<string, ImageOptions>((options, utils) => {
         ],
         inputRules: (nodeType) => [
             new InputRule(
-                /!\[(?<alt>.*?)]\((?<filename>.*?)(?=“|\))"?(?<title>[^"]+)?"?\)/,
+                /!\[(?<alt>.*?)]\((?<filename>.*?)\s*(?="|\))"?(?<title>[^"]+)?"?\)/,
                 (state, match, start, end) => {
                     const [okay, alt, src = '', title] = match;
                     const { tr } = state;


### PR DESCRIPTION
Current InputRule for image node uses the left double quotation mark (“, U+201C). 
Isn't this a typo for the normal quotation mark (", U+0022)?

CommonMark image requires a white space and a normal quotation mark before title strings.
https://spec.commonmark.org/0.30/#example-571
I have tried to make the regular expression closer to the Common Mark specification.