### PR TITLE
feat: 🎸 extend for atom

### DIFF
--- a/gh-pages/component/MilkdownEditor/editor.ts
+++ b/gh-pages/component/MilkdownEditor/editor.ts
@@ -19,7 +19,7 @@ import { prism } from '@milkdown/plugin-prism';
 import { slash } from '@milkdown/plugin-slash';
 import { tooltip } from '@milkdown/plugin-tooltip';
 import { upload } from '@milkdown/plugin-upload';
-import { gfm, paragraph } from '@milkdown/preset-gfm';
+import { gfm } from '@milkdown/preset-gfm';
 import { nord } from '@milkdown/theme-nord';
 
 import { codeSandBox } from './codeSandBox';

--- a/gh-pages/component/MilkdownEditor/editor.ts
+++ b/gh-pages/component/MilkdownEditor/editor.ts
@@ -19,7 +19,7 @@ import { prism } from '@milkdown/plugin-prism';
 import { slash } from '@milkdown/plugin-slash';
 import { tooltip } from '@milkdown/plugin-tooltip';
 import { upload } from '@milkdown/plugin-upload';
-import { gfm } from '@milkdown/preset-gfm';
+import { gfm, paragraph } from '@milkdown/preset-gfm';
 import { nord } from '@milkdown/theme-nord';
 
 import { codeSandBox } from './codeSandBox';

--- a/gh-pages/package.json
+++ b/gh-pages/package.json
@@ -17,7 +17,7 @@
         "react-loading-skeleton": "^2.2.0",
         "react-router-dom": "^5.2.0",
         "react-spinners": "^0.11.0",
-        "tslib": "^2.2.0",
+        "tslib": "^2.3.1",
         "unist-util-visit": "^4.0.0"
     },
     "devDependencies": {

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -17,7 +17,7 @@
     ],
     "dependencies": {
         "@playwright/test": "^1.16.0",
-        "tslib": "^2.2.0",
+        "tslib": "^2.3.1",
         "@milkdown/core": "workspace:*",
         "@milkdown/preset-commonmark": "workspace:*",
         "@milkdown/theme-nord": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
         "@milkdown/exception": "workspace: *",
         "@milkdown/prose": "workspace: *",
         "remark": "^14.0.1",
-        "tslib": "^2.2.0",
+        "tslib": "^2.3.1",
         "unified": "^10.1.0"
     }
 }

--- a/packages/ctx/package.json
+++ b/packages/ctx/package.json
@@ -27,6 +27,6 @@
     ],
     "dependencies": {
         "@milkdown/exception": "workspace: *",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -19,6 +19,6 @@
     ],
     "dependencies": {
         "@emotion/css": "^11.1.3",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/exception/package.json
+++ b/packages/exception/package.json
@@ -21,6 +21,6 @@
         "@milkdown/core": "*"
     },
     "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/plugin-clipboard/package.json
+++ b/packages/plugin-clipboard/package.json
@@ -26,6 +26,6 @@
     },
     "dependencies": {
         "@milkdown/utils": "workspace: *",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/plugin-collaborative/package.json
+++ b/packages/plugin-collaborative/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@milkdown/utils": "workspace:*",
         "@emotion/css": "^11.1.3",
-        "tslib": "^2.2.0",
+        "tslib": "^2.3.1",
         "y-prosemirror": "^1.0.9"
     },
     "devDependencies": {

--- a/packages/plugin-cursor/package.json
+++ b/packages/plugin-cursor/package.json
@@ -30,6 +30,6 @@
         "@types/prosemirror-gapcursor": "^1.0.4",
         "prosemirror-dropcursor": "^1.3.5",
         "prosemirror-gapcursor": "^1.1.5",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/plugin-diagram/package.json
+++ b/packages/plugin-diagram/package.json
@@ -32,7 +32,7 @@
         "@types/mermaid": "^8.2.7",
         "mermaid": "^8.12.1",
         "nanoid": "^3.1.25",
-        "tslib": "^2.2.0",
+        "tslib": "^2.3.1",
         "unist-util-visit": "^4.0.0"
     }
 }

--- a/packages/plugin-emoji/package.json
+++ b/packages/plugin-emoji/package.json
@@ -33,7 +33,7 @@
         "emoji-regex": "^9.2.2",
         "node-emoji": "^1.10.0",
         "remark-emoji": "^3.0.1",
-        "tslib": "^2.2.0",
+        "tslib": "^2.3.1",
         "twemoji": "^13.1.0",
         "unist-util-visit": "^4.0.0"
     }

--- a/packages/plugin-history/package.json
+++ b/packages/plugin-history/package.json
@@ -27,6 +27,6 @@
     "dependencies": {
         "@types/prosemirror-history": "^1.0.2",
         "prosemirror-history": "^1.1.3",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/plugin-indent/package.json
+++ b/packages/plugin-indent/package.json
@@ -27,6 +27,6 @@
     "dependencies": {
         "@emotion/css": "^11.1.3",
         "@milkdown/utils": "workspace: *",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/plugin-listener/package.json
+++ b/packages/plugin-listener/package.json
@@ -25,6 +25,6 @@
         "@milkdown/core": "*"
     },
     "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/plugin-math/package.json
+++ b/packages/plugin-math/package.json
@@ -30,7 +30,7 @@
         "@milkdown/utils": "workspace:*",
         "katex": "^0.13.18",
         "remark-math": "^5.1.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     },
     "devDependencies": {
         "@types/katex": "^0.11.1",

--- a/packages/plugin-prism/package.json
+++ b/packages/plugin-prism/package.json
@@ -28,6 +28,6 @@
         "@milkdown/utils": "workspace:*",
         "@types/refractor": "^3.0.0",
         "refractor": "^3.3.1",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/plugin-slash/package.json
+++ b/packages/plugin-slash/package.json
@@ -29,7 +29,7 @@
         "@emotion/css": "^11.1.3",
         "@milkdown/utils": "workspace:*",
         "smooth-scroll-into-view-if-needed": "^1.1.32",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     },
     "devDependencies": {
         "concurrently": "^6.0.2"

--- a/packages/plugin-table/package.json
+++ b/packages/plugin-table/package.json
@@ -29,7 +29,7 @@
         "@milkdown/utils": "workspace:*",
         "prosemirror-tables": "*",
         "remark-gfm": "^3.0.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     },
     "devDependencies": {
         "concurrently": "^6.0.2"

--- a/packages/plugin-tooltip/package.json
+++ b/packages/plugin-tooltip/package.json
@@ -29,7 +29,7 @@
     "dependencies": {
         "@emotion/css": "^11.1.3",
         "@milkdown/utils": "workspace: *",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     },
     "devDependencies": {
         "concurrently": "^6.0.2"

--- a/packages/plugin-upload/package.json
+++ b/packages/plugin-upload/package.json
@@ -26,6 +26,6 @@
     },
     "dependencies": {
         "@milkdown/utils": "workspace: *",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/preset-commonmark/package.json
+++ b/packages/preset-commonmark/package.json
@@ -32,7 +32,7 @@
         "@types/prosemirror-schema-list": "^1.0.3",
         "prosemirror-schema-list": "^1.1.4",
         "remark-inline-links": "^5.0.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     },
     "devDependencies": {
         "concurrently": "^6.0.2"

--- a/packages/preset-gfm/package.json
+++ b/packages/preset-gfm/package.json
@@ -33,7 +33,7 @@
         "@milkdown/utils": "workspace:*",
         "@types/prosemirror-schema-list": "^1.0.3",
         "prosemirror-schema-list": "^1.1.4",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     },
     "devDependencies": {
         "concurrently": "^6.0.2"

--- a/packages/prose/package.json
+++ b/packages/prose/package.json
@@ -33,6 +33,6 @@
         "prosemirror-state": "^1.3.4",
         "prosemirror-transform": "^1.3.2",
         "prosemirror-view": "^1.18.2",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@milkdown/utils": "workspace:*",
         "nanoid": "^3.1.25",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     },
     "peerDependencies": {
         "@milkdown/core": "*",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -22,6 +22,6 @@
     },
     "dependencies": {
         "@milkdown/exception": "workspace: *",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     }
 }

--- a/packages/utils/src/atom/atom-list.ts
+++ b/packages/utils/src/atom/atom-list.ts
@@ -1,9 +1,9 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import { MilkdownPlugin } from '@milkdown/core';
 
-import { Origin, PluginWithMetadata, UnknownRecord } from '../types';
+import { Origin, PluginWithMetadata } from '../types';
 
-type Atom = PluginWithMetadata<string, UnknownRecord>;
+type Atom = PluginWithMetadata;
 type Plugin = Atom | MilkdownPlugin;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/utils/src/atom/atom-list.ts
+++ b/packages/utils/src/atom/atom-list.ts
@@ -6,10 +6,13 @@ import { Origin, PluginWithMetadata, UnknownRecord } from '../types';
 type Atom = PluginWithMetadata<string, UnknownRecord>;
 type Plugin = Atom | MilkdownPlugin;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyOrigin = Origin<any, any, any>;
+
 const isAtom = (x: Plugin): x is Atom => Object.prototype.hasOwnProperty.call(x, 'origin');
 
 export class AtomList<T extends Plugin = Plugin> extends Array<T> {
-    private findThenRun<U extends Origin>(target: U, callback: (index: number) => void): this {
+    private findThenRun<U extends AnyOrigin>(target: U, callback: (index: number) => void): this {
         const index = this.findIndex((x) => isAtom(x) && x.origin === target);
         if (index < 0) return this;
 
@@ -18,19 +21,19 @@ export class AtomList<T extends Plugin = Plugin> extends Array<T> {
         return this;
     }
 
-    configure<U extends Origin>(target: U, config: Parameters<U>[0]): this {
+    configure<U extends AnyOrigin>(target: U, config: Parameters<U>[0]): this {
         return this.findThenRun(target, (index) => {
             this.splice(index, 1, target(config) as T);
         });
     }
 
-    replace<U extends Origin, Next extends Plugin>(target: U, next: Next): this {
+    replace<U extends AnyOrigin, Next extends Plugin>(target: U, next: Next): this {
         return this.findThenRun(target, (index) => {
             this.splice(index, 1, next as Plugin as T);
         });
     }
 
-    remove<U extends Origin>(target: U): this {
+    remove<U extends AnyOrigin>(target: U): this {
         return this.findThenRun(target, (index) => {
             this.splice(index, 1);
         });

--- a/packages/utils/src/factory/common.ts
+++ b/packages/utils/src/factory/common.ts
@@ -11,10 +11,11 @@ export const getClassName =
         return Array.isArray(classList) ? classList.filter((x) => x).join(' ') : classList;
     };
 
-export const commonPlugin = <Ret, Op extends CommonOptions>(
-    factory: (options: Op | undefined, utils: Utils) => Ret,
+export const commonPlugin = <Ret, Op extends CommonOptions, Args extends unknown[]>(
+    factory: (options: Op | undefined, utils: Utils, ...args: Args) => Ret,
     ctx: Ctx,
     options?: Op,
+    ...args: Args
 ): Ret => {
     try {
         const themeTool = ctx.get(themeToolCtx);
@@ -24,7 +25,7 @@ export const commonPlugin = <Ret, Op extends CommonOptions>(
             getStyle: (style) => (options?.headless ? '' : (style(themeTool) as string | undefined)),
         };
 
-        return factory(options, utils);
+        return factory(options, utils, ...args);
     } catch {
         throw themeMustInstalled();
     }

--- a/packages/utils/src/factory/create-mark.ts
+++ b/packages/utils/src/factory/create-mark.ts
@@ -1,7 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import { Mark, markFactory } from '@milkdown/core';
 
-import { Factory, Origin, PluginWithMetadata, UnknownRecord } from '../types';
+import { AtomOptional, Factory, Options, Origin, PluginWithMetadata, UnknownRecord, Utils } from '../types';
 import { commonPlugin } from './common';
 import { createKeymap } from './keymap';
 
@@ -24,6 +24,19 @@ export const createMark = <SupportedKeys extends string = string, T extends Unkn
         plugin.origin = origin;
 
         return plugin;
+    };
+    origin.extend = <SupportedKeysExtended extends SupportedKeys = SupportedKeys, ObjExtended extends T = T>(
+        extendFactory: (
+            options: Options<SupportedKeysExtended, ObjExtended, Mark> | undefined,
+            utils: Utils,
+            original: Mark & AtomOptional<SupportedKeys>,
+        ) => Mark & AtomOptional<SupportedKeysExtended>,
+    ) => {
+        return createMark<SupportedKeysExtended, ObjExtended>((options, utils) => {
+            const original = factory(options as T, utils);
+            const extended = extendFactory(options, utils, original);
+            return extended;
+        });
     };
 
     return origin;

--- a/packages/utils/src/factory/create-mark.ts
+++ b/packages/utils/src/factory/create-mark.ts
@@ -1,7 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import { Mark, markFactory } from '@milkdown/core';
 
-import { AtomOptional, Factory, Options, Origin, PluginWithMetadata, UnknownRecord, Utils } from '../types';
+import { ExtendFactory, Factory, Origin, PluginWithMetadata, UnknownRecord } from '../types';
 import { commonPlugin } from './common';
 import { createKeymap } from './keymap';
 
@@ -26,11 +26,7 @@ export const createMark = <SupportedKeys extends string = string, T extends Unkn
         return plugin;
     };
     origin.extend = <SupportedKeysExtended extends SupportedKeys = SupportedKeys, ObjExtended extends T = T>(
-        extendFactory: (
-            options: Options<SupportedKeysExtended, ObjExtended, Mark> | undefined,
-            utils: Utils,
-            original: Mark & AtomOptional<SupportedKeys>,
-        ) => Mark & AtomOptional<SupportedKeysExtended>,
+        extendFactory: ExtendFactory<SupportedKeys, SupportedKeysExtended, ObjExtended, Mark>,
     ) => {
         return createMark<SupportedKeysExtended, ObjExtended>((options, utils) => {
             const original = factory(options as T, utils);

--- a/packages/utils/src/factory/create-node.ts
+++ b/packages/utils/src/factory/create-node.ts
@@ -1,7 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import { Node, nodeFactory } from '@milkdown/core';
 
-import { Factory, Origin, PluginWithMetadata, UnknownRecord } from '../types';
+import { AtomOptional, Factory, Options, Origin, PluginWithMetadata, UnknownRecord, Utils } from '../types';
 import { commonPlugin } from './common';
 import { createKeymap } from './keymap';
 
@@ -24,6 +24,18 @@ export const createNode = <SupportedKeys extends string = string, T extends Unkn
         plugin.origin = origin;
 
         return plugin;
+    };
+    origin.extend = <SupportedKeysExtended extends SupportedKeys = SupportedKeys, ObjExtended extends T = T>(
+        extendFactory: (
+            options: Options<SupportedKeysExtended, ObjExtended, Node> | undefined,
+            utils: Utils,
+            original: Node & AtomOptional<SupportedKeys>,
+        ) => Node & AtomOptional<SupportedKeysExtended>,
+    ) => {
+        return createNode<SupportedKeysExtended, ObjExtended>((options, utils) => {
+            const original = factory(options as T, utils);
+            return extendFactory(options, utils, original);
+        });
     };
 
     return origin;

--- a/packages/utils/src/factory/create-node.ts
+++ b/packages/utils/src/factory/create-node.ts
@@ -1,7 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import { Node, nodeFactory } from '@milkdown/core';
 
-import { AtomOptional, Factory, Options, Origin, PluginWithMetadata, UnknownRecord, Utils } from '../types';
+import { ExtendFactory, Factory, Origin, PluginWithMetadata, UnknownRecord } from '../types';
 import { commonPlugin } from './common';
 import { createKeymap } from './keymap';
 
@@ -26,11 +26,7 @@ export const createNode = <SupportedKeys extends string = string, T extends Unkn
         return plugin;
     };
     origin.extend = <SupportedKeysExtended extends SupportedKeys = SupportedKeys, ObjExtended extends T = T>(
-        extendFactory: (
-            options: Options<SupportedKeysExtended, ObjExtended, Node> | undefined,
-            utils: Utils,
-            original: Node & AtomOptional<SupportedKeys>,
-        ) => Node & AtomOptional<SupportedKeysExtended>,
+        extendFactory: ExtendFactory<SupportedKeys, SupportedKeysExtended, ObjExtended, Node>,
     ) => {
         return createNode<SupportedKeysExtended, ObjExtended>((options, utils) => {
             const original = factory(options as T, utils);

--- a/packages/utils/src/factory/create-prose-plugin.ts
+++ b/packages/utils/src/factory/create-prose-plugin.ts
@@ -2,7 +2,7 @@
 import { prosePluginFactory } from '@milkdown/core';
 import type { Plugin } from '@milkdown/prose';
 
-import { AtomOptional, Factory, Options, Origin, PluginWithMetadata, UnknownRecord, Utils } from '../types';
+import { ExtendFactory, Factory, Origin, PluginWithMetadata, UnknownRecord } from '../types';
 import { commonPlugin } from './common';
 
 type PluginData = {
@@ -24,11 +24,7 @@ export const createProsePlugin = <Obj extends UnknownRecord = UnknownRecord>(
         return plugin;
     };
     origin.extend = <ObjExtended extends Obj = Obj>(
-        extendFactory: (
-            options: Options<string, ObjExtended, PluginData> | undefined,
-            utils: Utils,
-            original: PluginData & AtomOptional<string>,
-        ) => PluginData & AtomOptional<string>,
+        extendFactory: ExtendFactory<string, string, ObjExtended, PluginData>,
     ) => {
         return createProsePlugin<ObjExtended>((options, utils) => {
             const original = factory(options as Obj, utils);

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -51,12 +51,22 @@ export type Utils = {
     readonly ctx: Ctx;
 };
 
-export type Origin<S extends string = string, Obj extends UnknownRecord = UnknownRecord, Type = unknown> = (
-    options?: Options<S, Obj, Type>,
-) => PluginWithMetadata<S, Obj, Type>;
+export type Origin<S extends string = string, Obj extends UnknownRecord = UnknownRecord, Type = unknown> = {
+    (options?: Options<S, Obj, Type>): PluginWithMetadata<S, Obj, Type>;
+    extend: <SupportedKeysExtended extends S = S, ObjExtended extends Obj = Obj>(
+        extendFactory: (
+            options: Options<SupportedKeysExtended, ObjExtended, Type> | undefined,
+            utils: Utils,
+            original: Type & AtomOptional<S>,
+        ) => Type & AtomOptional<SupportedKeysExtended>,
+    ) => Origin<SupportedKeysExtended, ObjExtended, Type>;
+};
 
 export type PluginWithMetadata<
     SupportedKeys extends string = string,
     Obj extends UnknownRecord = UnknownRecord,
     Type = unknown,
-> = MilkdownPlugin & { origin: Origin<SupportedKeys, Obj, Type>; id: string };
+> = MilkdownPlugin & {
+    origin: Origin<SupportedKeys, Obj, Type>;
+    id: string;
+};

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -51,14 +51,21 @@ export type Utils = {
     readonly ctx: Ctx;
 };
 
+export type ExtendFactory<
+    OriginalSupportedKeys extends string,
+    SupportedKeys extends OriginalSupportedKeys,
+    Obj extends UnknownRecord,
+    Type = unknown,
+> = (
+    options: Options<SupportedKeys, Obj, Type> | undefined,
+    utils: Utils,
+    original: Type & AtomOptional<OriginalSupportedKeys>,
+) => Type & AtomOptional<SupportedKeys>;
+
 export type Origin<S extends string = string, Obj extends UnknownRecord = UnknownRecord, Type = unknown> = {
     (options?: Options<S, Obj, Type>): PluginWithMetadata<S, Obj, Type>;
     extend: <SupportedKeysExtended extends S = S, ObjExtended extends Obj = Obj>(
-        extendFactory: (
-            options: Options<SupportedKeysExtended, ObjExtended, Type> | undefined,
-            utils: Utils,
-            original: Type & AtomOptional<S>,
-        ) => Type & AtomOptional<SupportedKeysExtended>,
+        extendFactory: ExtendFactory<S, SupportedKeysExtended, ObjExtended, Type>,
     ) => Origin<SupportedKeysExtended, ObjExtended, Type>;
 };
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@milkdown/utils": "workspace:*",
         "nanoid": "^3.1.25",
-        "tslib": "^2.2.0"
+        "tslib": "^2.3.1"
     },
     "peerDependencies": {
         "@milkdown/core": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,7 +139,7 @@ importers:
       react-loading-skeleton: ^2.2.0
       react-router-dom: ^5.2.0
       react-spinners: ^0.11.0
-      tslib: ^2.2.0
+      tslib: ^2.3.1
       unist-util-visit: ^4.0.0
     dependencies:
       '@codemirror/basic-setup': 0.18.2
@@ -175,7 +175,7 @@ importers:
       '@milkdown/theme-nord': workspace:*
       '@playwright/test': ^1.16.0
       start-server-and-test: ^1.13.0
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@milkdown/core': link:../packages/core
       '@milkdown/design-system': link:../packages/design-system
@@ -193,7 +193,7 @@ importers:
       '@milkdown/exception': 'workspace: *'
       '@milkdown/prose': 'workspace: *'
       remark: ^14.0.1
-      tslib: ^2.2.0
+      tslib: ^2.3.1
       unified: ^10.1.0
     dependencies:
       '@milkdown/ctx': link:../ctx
@@ -207,7 +207,7 @@ importers:
   packages/ctx:
     specifiers:
       '@milkdown/exception': 'workspace: *'
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@milkdown/exception': link:../exception
       tslib: 2.3.1
@@ -215,21 +215,21 @@ importers:
   packages/design-system:
     specifiers:
       '@emotion/css': ^11.1.3
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@emotion/css': 11.5.0
       tslib: 2.3.1
 
   packages/exception:
     specifiers:
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       tslib: 2.3.1
 
   packages/plugin-clipboard:
     specifiers:
       '@milkdown/utils': 'workspace: *'
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@milkdown/utils': link:../utils
       tslib: 2.3.1
@@ -238,7 +238,7 @@ importers:
     specifiers:
       '@emotion/css': ^11.1.3
       '@milkdown/utils': workspace:*
-      tslib: ^2.2.0
+      tslib: ^2.3.1
       y-prosemirror: ^1.0.9
       y-protocols: ^1.0.5
       y-websocket: ^1.3.16
@@ -260,7 +260,7 @@ importers:
       '@types/prosemirror-gapcursor': ^1.0.4
       prosemirror-dropcursor: ^1.3.5
       prosemirror-gapcursor: ^1.1.5
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@emotion/css': 11.5.0
       '@types/prosemirror-dropcursor': 1.0.3
@@ -276,7 +276,7 @@ importers:
       '@types/mermaid': ^8.2.7
       mermaid: ^8.12.1
       nanoid: ^3.1.25
-      tslib: ^2.2.0
+      tslib: ^2.3.1
       unist-util-visit: ^4.0.0
     dependencies:
       '@emotion/css': 11.5.0
@@ -297,7 +297,7 @@ importers:
       emoji-regex: ^9.2.2
       node-emoji: ^1.10.0
       remark-emoji: ^3.0.1
-      tslib: ^2.2.0
+      tslib: ^2.3.1
       twemoji: ^13.1.0
       unist-util-visit: ^4.0.0
     dependencies:
@@ -317,7 +317,7 @@ importers:
     specifiers:
       '@types/prosemirror-history': ^1.0.2
       prosemirror-history: ^1.1.3
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@types/prosemirror-history': 1.0.3
       prosemirror-history: 1.2.0
@@ -327,7 +327,7 @@ importers:
     specifiers:
       '@emotion/css': ^11.1.3
       '@milkdown/utils': 'workspace: *'
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@emotion/css': 11.5.0
       '@milkdown/utils': link:../utils
@@ -335,7 +335,7 @@ importers:
 
   packages/plugin-listener:
     specifiers:
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       tslib: 2.3.1
 
@@ -347,7 +347,7 @@ importers:
       concurrently: ^6.0.2
       katex: ^0.13.18
       remark-math: ^5.1.0
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@emotion/css': 11.5.0
       '@milkdown/utils': link:../utils
@@ -363,7 +363,7 @@ importers:
       '@milkdown/utils': workspace:*
       '@types/refractor': ^3.0.0
       refractor: ^3.3.1
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@milkdown/utils': link:../utils
       '@types/refractor': 3.0.2
@@ -376,7 +376,7 @@ importers:
       '@milkdown/utils': workspace:*
       concurrently: ^6.0.2
       smooth-scroll-into-view-if-needed: ^1.1.32
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@emotion/css': 11.5.0
       '@milkdown/utils': link:../utils
@@ -392,7 +392,7 @@ importers:
       concurrently: ^6.0.2
       prosemirror-tables: '*'
       remark-gfm: ^3.0.0
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@emotion/css': 11.5.0
       '@milkdown/utils': link:../utils
@@ -407,7 +407,7 @@ importers:
       '@emotion/css': ^11.1.3
       '@milkdown/utils': 'workspace: *'
       concurrently: ^6.0.2
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@emotion/css': 11.5.0
       '@milkdown/utils': link:../utils
@@ -418,7 +418,7 @@ importers:
   packages/plugin-upload:
     specifiers:
       '@milkdown/utils': 'workspace: *'
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@milkdown/utils': link:../utils
       tslib: 2.3.1
@@ -431,7 +431,7 @@ importers:
       concurrently: ^6.0.2
       prosemirror-schema-list: ^1.1.4
       remark-inline-links: ^5.0.0
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@emotion/css': 11.5.0
       '@milkdown/utils': link:../utils
@@ -451,7 +451,7 @@ importers:
       '@types/prosemirror-schema-list': ^1.0.3
       concurrently: ^6.0.2
       prosemirror-schema-list: ^1.1.4
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@emotion/css': 11.5.0
       '@milkdown/plugin-table': link:../plugin-table
@@ -480,7 +480,7 @@ importers:
       prosemirror-state: ^1.3.4
       prosemirror-transform: ^1.3.2
       prosemirror-view: ^1.18.2
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@milkdown/exception': link:../exception
       '@types/prosemirror-commands': 1.0.4
@@ -507,7 +507,7 @@ importers:
       nanoid: ^3.1.25
       react: '*'
       react-dom: '*'
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@milkdown/utils': link:../utils
       nanoid: 3.1.30
@@ -529,7 +529,7 @@ importers:
   packages/utils:
     specifiers:
       '@milkdown/exception': 'workspace: *'
-      tslib: ^2.2.0
+      tslib: ^2.3.1
     dependencies:
       '@milkdown/exception': link:../exception
       tslib: 2.3.1
@@ -538,7 +538,7 @@ importers:
     specifiers:
       '@milkdown/utils': workspace:*
       nanoid: ^3.1.25
-      tslib: ^2.2.0
+      tslib: ^2.3.1
       vue: ^3.0.0
     dependencies:
       '@milkdown/utils': link:../utils


### PR DESCRIPTION
Usage:

```typescript
import { commonmark, heading } from '@milkdown/commonmark';

const myHeadingNode = heading.extend((options, utils, original) => {
 return {
    ...original,
    schema: myCustomSchema,
  };
});

editor.use(commonmark.replace(heading, myHeadingNode());
```