### PR TITLE
feat: 🎸 use button elements within menu, w classes and labels

### DIFF
--- a/packages/design-system/src/default-value.ts
+++ b/packages/design-system/src/default-value.ts
@@ -25,4 +25,7 @@ export const slots: ThemeTool['slots'] = {
         div.textContent = id;
         return div;
     },
+    label: (id: string) => {
+        return id;
+    },
 };

--- a/packages/design-system/src/types.ts
+++ b/packages/design-system/src/types.ts
@@ -44,6 +44,7 @@ export type Icon =
 
 export type Slots = {
     icon: (id: Icon, config?: Record<string, string | number | boolean>) => HTMLElement;
+    label: (id: Icon, config?: Record<string, string | number | boolean>) => string;
 };
 
 export type MixinFactory = {

--- a/packages/plugin-menu/src/button.ts
+++ b/packages/plugin-menu/src/button.ts
@@ -20,6 +20,8 @@ export type ButtonConfig<T = any> = {
 export const button = (utils: Utils, config: ButtonConfig, ctx: Ctx) => {
     const buttonStyle = utils.getStyle((themeTool) => {
         return css`
+            border: 0;
+            box-sizing: unset;
             width: 1.5rem;
             height: 1.5rem;
             padding: 0.25rem;
@@ -41,16 +43,27 @@ export const button = (utils: Utils, config: ButtonConfig, ctx: Ctx) => {
                 background-color: ${themeTool.palette('secondary', 0.12)};
                 color: ${themeTool.palette('primary')};
             }
+
+            &:disabled {
+                display: none;
+            }
         `;
     });
 
-    const $button = document.createElement('div');
+    const $button = document.createElement('button');
+    $button.setAttribute('type', 'button');
+    $button.classList.add('button');
     if (buttonStyle) {
         $button.classList.add(buttonStyle);
     }
+    const $label = utils.themeTool.slots.label(config.icon);
+    if ($label) {
+        $button.setAttribute('aria-label', $label);
+        $button.setAttribute('title', $label);
+    }
     const $icon = utils.themeTool.slots.icon(config.icon);
     $button.appendChild($icon);
-    $button.addEventListener('mousedown', (e) => {
+    $button.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         ctx.get(commandsCtx).call(config.key, config.options);

--- a/packages/plugin-menu/src/divider.ts
+++ b/packages/plugin-menu/src/divider.ts
@@ -17,6 +17,7 @@ export const divider = (utils: Utils) => {
         `;
     });
     const $divider = document.createElement('div');
+    $divider.classList.add('divider');
     if (dividerStyle) {
         $divider.classList.add(dividerStyle);
     }

--- a/packages/plugin-menu/src/manager.ts
+++ b/packages/plugin-menu/src/manager.ts
@@ -50,9 +50,9 @@ export class Manager {
                 if (config.disabled) {
                     const disabled = config.disabled(view);
                     if (disabled) {
-                        config.$.classList.add('disabled');
+                        config.$.setAttribute('disabled', 'true');
                     } else {
-                        config.$.classList.remove('disabled');
+                        config.$.removeAttribute('disabled');
                     }
                 }
                 return;
@@ -63,14 +63,18 @@ export class Manager {
                     const disabled = config.disabled(view);
                     if (disabled) {
                         config.$.classList.add('disabled');
+                        config.$.children[0].setAttribute('disabled', 'true');
                     } else {
                         config.$.classList.remove('disabled');
+                        config.$.children[0].removeAttribute('disabled');
                     }
                 }
             }
 
             if (config.type === 'divider') {
-                const disabled = config.group.every((x) => x.classList.contains('disabled'));
+                const disabled = config.group.every(
+                    (x) => x.getAttribute('disabled') || x.classList.contains('disabled'),
+                );
                 if (disabled) {
                     config.$.classList.add('disabled');
                 } else {

--- a/packages/plugin-menu/src/select.ts
+++ b/packages/plugin-menu/src/select.ts
@@ -24,9 +24,7 @@ export type SelectConfig<T = any> = {
 export const select = (utils: Utils, config: SelectConfig, ctx: Ctx, view: EditorView) => {
     const selectStyle = utils.getStyle((themeTool) => {
         return css`
-            width: 12.375rem;
             flex-shrink: 0;
-            cursor: pointer;
             font-weight: 500;
             font-size: 0.875rem;
 
@@ -34,6 +32,11 @@ export const select = (utils: Utils, config: SelectConfig, ctx: Ctx, view: Edito
             ${themeTool.mixin.border('left')};
 
             .menu-selector {
+                border: 0;
+                box-sizing: unset;
+                cursor: pointer;
+                font: inherit;
+                text-align: left;
                 justify-content: space-between;
                 align-items: center;
                 color: ${themeTool.palette('neutral', 0.87)};
@@ -41,6 +44,11 @@ export const select = (utils: Utils, config: SelectConfig, ctx: Ctx, view: Edito
                 padding: 0.25rem 0.5rem;
                 margin: 0.5rem;
                 background: ${themeTool.palette('secondary', 0.12)};
+                width: 10.375rem;
+
+                &:disabled {
+                    display: none;
+                }
             }
 
             .menu-selector-value {
@@ -62,8 +70,16 @@ export const select = (utils: Utils, config: SelectConfig, ctx: Ctx, view: Edito
             }
 
             .menu-selector-list-item {
+                background-color: transparent;
+                border: 0;
+                cursor: pointer;
+                display: block;
+                font: inherit;
+                text-align: left;
                 padding: 0.75rem 1rem;
                 line-height: 1.5rem;
+                width: 100%;
+
                 &:hover {
                     background: ${themeTool.palette('secondary', 0.12)};
                     color: ${themeTool.palette('primary')};
@@ -87,9 +103,10 @@ export const select = (utils: Utils, config: SelectConfig, ctx: Ctx, view: Edito
     const selectorWrapper = document.createElement('div');
     selectorWrapper.classList.add('menu-selector-wrapper', 'fold');
 
-    const selector = document.createElement('div');
+    const selector = document.createElement('button');
+    selector.setAttribute('type', 'button');
     selector.classList.add('menu-selector', 'fold');
-    selector.addEventListener('mousedown', (e) => {
+    selector.addEventListener('click', (e) => {
         e.preventDefault();
         e.stopPropagation();
         selectorWrapper.classList.toggle('fold');
@@ -97,7 +114,7 @@ export const select = (utils: Utils, config: SelectConfig, ctx: Ctx, view: Edito
             selectorWrapper.getBoundingClientRect().left - view.dom.getBoundingClientRect().left
         }px`;
     });
-    view.dom.addEventListener('mousedown', () => {
+    view.dom.addEventListener('click', () => {
         selectorWrapper.classList.add('fold');
     });
 
@@ -106,6 +123,7 @@ export const select = (utils: Utils, config: SelectConfig, ctx: Ctx, view: Edito
     selectorValue.textContent = config.text;
 
     const selectorButton = utils.themeTool.slots.icon('downArrow');
+    selectorButton.setAttribute('aria-hidden', 'true');
 
     selectorWrapper.appendChild(selector);
     selector.appendChild(selectorValue);
@@ -114,17 +132,17 @@ export const select = (utils: Utils, config: SelectConfig, ctx: Ctx, view: Edito
     const selectorList = document.createElement('div');
     selectorList.classList.add('menu-selector-list');
     config.options.forEach((option) => {
-        const selectorListItem = document.createElement('div');
-
+        const selectorListItem = document.createElement('button');
+        selectorListItem.setAttribute('type', 'button');
         selectorListItem.dataset.id = option.id;
         selectorListItem.textContent = option.text;
         selectorListItem.classList.add('menu-selector-list-item');
         selectorList.appendChild(selectorListItem);
     });
 
-    selectorList.addEventListener('mousedown', (e) => {
+    selectorList.addEventListener('click', (e) => {
         const { target } = e;
-        if (target instanceof HTMLDivElement && target.dataset.id) {
+        if (target instanceof HTMLButtonElement && target.dataset.id) {
             ctx.get(commandsCtx).call(...config.onSelect(target.dataset.id, view));
             selectorWrapper.classList.add('fold');
         }

--- a/packages/theme-nord/src/slots.ts
+++ b/packages/theme-nord/src/slots.ts
@@ -2,47 +2,154 @@
 
 import { Icon, ThemePack } from '@milkdown/design-system';
 
-const iconMapping: Record<Icon, string> = {
-    h1: 'looks_one',
-    h2: 'looks_two',
-    h3: 'looks_3',
-    loading: 'hourglass_empty',
-    quote: 'format_quote',
-    code: 'code',
-    table: 'table_chart',
-    divider: 'horizontal_rule',
-    image: 'image',
-    brokenImage: 'broken_image',
-    bulletList: 'format_list_bulleted',
-    orderedList: 'format_list_numbered',
-    taskList: 'checklist',
-    bold: 'format_bold',
-    italic: 'format_italic',
-    inlineCode: 'code',
-    strikeThrough: 'strikethrough_s',
-    link: 'link',
-    leftArrow: 'chevron_left',
-    rightArrow: 'chevron_right',
-    upArrow: 'expand_less',
-    downArrow: 'expand_more',
-    alignLeft: 'format_align_left',
-    alignRight: 'format_align_right',
-    alignCenter: 'format_align_center',
-    delete: 'delete',
-    select: 'select_all',
-    unchecked: 'check_box_outline_blank',
-    checked: 'check_box',
-    undo: 'turn_left',
-    redo: 'turn_right',
-    liftList: 'format_indent_decrease',
-    sinkList: 'format_indent_increase',
+type Slot = {
+    icon: string;
+    label: string;
+};
+
+const iconMapping: Record<Icon, Slot> = {
+    h1: {
+        label: 'h1',
+        icon: 'looks_one',
+    },
+    h2: {
+        label: 'h2',
+        icon: 'looks_two',
+    },
+    h3: {
+        label: 'h3',
+        icon: 'looks_3',
+    },
+    loading: {
+        label: 'loading',
+        icon: 'hourglass_empty',
+    },
+    quote: {
+        label: 'quote',
+        icon: 'format_quote',
+    },
+    code: {
+        label: 'code',
+        icon: 'code',
+    },
+    table: {
+        label: 'table',
+        icon: 'table_chart',
+    },
+    divider: {
+        label: 'divider',
+        icon: 'horizontal_rule',
+    },
+    image: {
+        label: 'image',
+        icon: 'image',
+    },
+    brokenImage: {
+        label: 'broken image',
+        icon: 'broken_image',
+    },
+    bulletList: {
+        label: 'bullet list',
+        icon: 'format_list_bulleted',
+    },
+    orderedList: {
+        label: 'ordered list',
+        icon: 'format_list_numbered',
+    },
+    taskList: {
+        label: 'task list',
+        icon: 'checklist',
+    },
+    bold: {
+        label: 'bold',
+        icon: 'format_bold',
+    },
+    italic: {
+        label: 'italic',
+        icon: 'format_italic',
+    },
+    inlineCode: {
+        label: 'inline code',
+        icon: 'code',
+    },
+    strikeThrough: {
+        label: 'strike through',
+        icon: 'strikethrough_s',
+    },
+    link: {
+        label: 'link',
+        icon: 'link',
+    },
+    leftArrow: {
+        label: 'left arrow',
+        icon: 'chevron_left',
+    },
+    rightArrow: {
+        label: 'right arrow',
+        icon: 'chevron_right',
+    },
+    upArrow: {
+        label: 'up arrow',
+        icon: 'expand_less',
+    },
+    downArrow: {
+        label: 'down arrow',
+        icon: 'expand_more',
+    },
+    alignLeft: {
+        label: 'align left',
+        icon: 'format_align_left',
+    },
+    alignRight: {
+        label: 'align right',
+        icon: 'format_align_right',
+    },
+    alignCenter: {
+        label: 'align center',
+        icon: 'format_align_center',
+    },
+    delete: {
+        label: 'delete',
+        icon: 'delete',
+    },
+    select: {
+        label: 'select',
+        icon: 'select_all',
+    },
+    unchecked: {
+        label: 'unchecked',
+        icon: 'check_box_outline_blank',
+    },
+    checked: {
+        label: 'checked',
+        icon: 'check_box',
+    },
+    undo: {
+        label: 'undo',
+        icon: 'turn_left',
+    },
+    redo: {
+        label: 'redo',
+        icon: 'turn_right',
+    },
+    liftList: {
+        label: 'lift list',
+        icon: 'format_indent_decrease',
+    },
+    sinkList: {
+        label: 'sink list',
+        icon: 'format_indent_increase',
+    },
 };
 
 export const slots: ThemePack['slots'] = () => ({
     icon: (id) => {
         const span = document.createElement('span');
         span.className = 'icon material-icons material-icons-outlined';
-        span.textContent = iconMapping[id];
+        span.textContent = iconMapping[id].icon;
         return span;
+    },
+    label: (id) => {
+        return iconMapping[id].label;
     },
 });


### PR DESCRIPTION
- Use HTML button elements rather than divs to improve semantics and accessibility
- Add classes to buttons and dividers to improve the ability to customise the styling of those elements outside of the theme
- Add a human-readable label for slots which is used as title and aria-label on the menu buttons

✅ Closes: [218](https://github.com/Saul-Mirone/milkdown/issues/218)
