### PR TITLE
chore: 🤖 Add 'peerDependenciesMeta' to package.json

### DIFF
--- a/packages/exception/package.json
+++ b/packages/exception/package.json
@@ -26,6 +26,11 @@
     "peerDependencies": {
         "@milkdown/core": "*"
     },
+    "peerDependenciesMeta": {
+        "@milkdown/core": {
+            "optional": true
+        }
+    },
     "dependencies": {
         "tslib": "^2.3.1"
     }


### PR DESCRIPTION
For those project using yarn, yarn install will yield warning for
peerDependency @milkdown/core. Add an option to elimiate it.