### PR TITLE
Make emotion can be configured

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -6,12 +6,12 @@ function readPackage(pkg) {
 
     // Disable peer dependencies warning for y-prosemirror and @emotion/css
     if (pkg.name === 'y-prosemirror') {
-        pkg.peerDependencies['prosemirror-model'] = '*';
-        pkg.peerDependencies['prosemirror-state'] = '*';
-        pkg.peerDependencies['prosemirror-view'] = '*';
+        delete pkg.peerDependencies['prosemirror-model'];
+        delete pkg.peerDependencies['prosemirror-state'];
+        delete pkg.peerDependencies['prosemirror-view'];
     }
     if (pkg.name === '@emotion/css') {
-        pkg.peerDependencies['@babel/core'] = '*';
+        delete pkg.peerDependencies['@babel/core'];
     }
 
     return pkg;

--- a/packages/core/src/internal-plugin/theme.ts
+++ b/packages/core/src/internal-plugin/theme.ts
@@ -2,6 +2,8 @@
 import { createSlice, MilkdownPlugin } from '@milkdown/ctx';
 import { Emotion, init, injectVar, Options, pack2Tool, ThemePack, ThemeTool } from '@milkdown/design-system';
 
+import { ConfigReady } from '.';
+
 export const themeToolCtx = createSlice<ThemeTool>(
     {
         mixin: {} as never,
@@ -21,11 +23,12 @@ export const themeFactory =
     (createThemePack: (emotion: Emotion) => ThemePack): MilkdownPlugin =>
     (pre) => {
         pre.inject(themeToolCtx).inject(themeConfigCtx).inject(emotionCtx);
-        return (ctx) => {
+        return async (ctx) => {
+            await ctx.wait(ConfigReady);
             const emotion = init(ctx.get(themeConfigCtx));
             const themePack = createThemePack(emotion);
 
-            injectVar(themePack);
+            injectVar(themePack, emotion);
             const tool = pack2Tool(themePack);
 
             ctx.set(emotionCtx, emotion);

--- a/packages/core/src/internal-plugin/theme.ts
+++ b/packages/core/src/internal-plugin/theme.ts
@@ -1,6 +1,6 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import { createSlice, MilkdownPlugin } from '@milkdown/ctx';
-import { injectVar, pack2Tool, ThemePack, ThemeTool } from '@milkdown/design-system';
+import { Emotion, init, injectVar, Options, pack2Tool, ThemePack, ThemeTool } from '@milkdown/design-system';
 
 export const themeToolCtx = createSlice<ThemeTool>(
     {
@@ -12,17 +12,23 @@ export const themeToolCtx = createSlice<ThemeTool>(
     },
     'ThemeTool',
 );
+export const themeConfigCtx = createSlice<Options>({ key: 'milkdown' }, 'ThemeConfig');
+export const emotionCtx = createSlice<Emotion>({} as Emotion, 'Emotion');
 
-export type { ThemeTool } from '@milkdown/design-system';
+export type { Emotion, ThemeTool } from '@milkdown/design-system';
 
 export const themeFactory =
-    (themePack: ThemePack): MilkdownPlugin =>
+    (createThemePack: (emotion: Emotion) => ThemePack): MilkdownPlugin =>
     (pre) => {
-        pre.inject(themeToolCtx);
+        pre.inject(themeToolCtx).inject(themeConfigCtx).inject(emotionCtx);
         return (ctx) => {
+            const emotion = init(ctx.get(themeConfigCtx));
+            const themePack = createThemePack(emotion);
+
             injectVar(themePack);
             const tool = pack2Tool(themePack);
 
+            ctx.set(emotionCtx, emotion);
             ctx.set(themeToolCtx, tool);
         };
     };

--- a/packages/core/src/internal-plugin/theme.ts
+++ b/packages/core/src/internal-plugin/theme.ts
@@ -14,7 +14,7 @@ export const themeToolCtx = createSlice<ThemeTool>(
     },
     'ThemeTool',
 );
-export const themeConfigCtx = createSlice<Options>({ key: 'milkdown' }, 'ThemeConfig');
+export const emotionConfigCtx = createSlice<Options>({ key: 'milkdown' }, 'EmotionConfig');
 export const emotionCtx = createSlice<Emotion>({} as Emotion, 'Emotion');
 
 export type { Emotion, ThemeTool } from '@milkdown/design-system';
@@ -22,10 +22,10 @@ export type { Emotion, ThemeTool } from '@milkdown/design-system';
 export const themeFactory =
     (createThemePack: (emotion: Emotion) => ThemePack): MilkdownPlugin =>
     (pre) => {
-        pre.inject(themeToolCtx).inject(themeConfigCtx).inject(emotionCtx);
+        pre.inject(themeToolCtx).inject(emotionConfigCtx).inject(emotionCtx);
         return async (ctx) => {
             await ctx.wait(ConfigReady);
-            const emotion = init(ctx.get(themeConfigCtx));
+            const emotion = init(ctx.get(emotionConfigCtx));
             const themePack = createThemePack(emotion);
 
             injectVar(themePack, emotion);

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -17,6 +17,7 @@
         "src"
     ],
     "dependencies": {
+        "@emotion/cache": "^11.7.1",
         "@emotion/css": "^11.1.3",
         "tslib": "^2.3.1"
     }

--- a/packages/design-system/src/emotion.ts
+++ b/packages/design-system/src/emotion.ts
@@ -1,0 +1,6 @@
+/* Copyright 2021, Milkdown by Mirone. */
+import createEmotion, { Emotion, Options } from '@emotion/css/create-instance';
+
+export type { Emotion, Options } from '@emotion/css/create-instance';
+
+export const init = (options?: Options): Emotion => createEmotion(options);

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -66,4 +66,6 @@ export const pack2Tool = (themePack: ThemePack): ThemeTool => {
     return tool;
 };
 
+export type { Emotion, Options } from './emotion';
+export { init } from './emotion';
 export type { Color, Font, Icon, Size, ThemePack, ThemeTool } from './types';

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,13 +1,13 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { injectGlobal } from '@emotion/css';
 
 import * as D from './default-value';
+import type { Emotion } from './emotion';
 import { obj2color, obj2var } from './transformer';
 import { Color, PR, ThemePack, ThemeTool } from './types';
 
-export const injectVar = (themePack: ThemePack) => {
+export const injectVar = (themePack: ThemePack, emotion: Emotion) => {
     const { color = {}, font, size = {} } = themePack;
-    const css = injectGlobal;
+    const css = emotion.injectGlobal;
     css`
         :root {
             ${obj2color(color)};

--- a/packages/plugin-collaborative/package.json
+++ b/packages/plugin-collaborative/package.json
@@ -27,7 +27,6 @@
         "@milkdown/core": "workspace:*",
         "@milkdown/prose": "workspace:*",
         "@milkdown/utils": "workspace:*",
-        "@emotion/css": "^11.1.3",
         "tslib": "^2.3.1",
         "yjs": "^13.5.11",
         "y-prosemirror": "^1.0.9",

--- a/packages/plugin-collaborative/src/injectStyle.ts
+++ b/packages/plugin-collaborative/src/injectStyle.ts
@@ -1,8 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { injectGlobal } from '@emotion/css';
-import { ThemeTool } from '@milkdown/core';
+import { Emotion, ThemeTool } from '@milkdown/core';
 
-export const injectStyle = ({ size, palette, mixin }: ThemeTool) => {
+export const injectStyle = ({ size, palette, mixin }: ThemeTool, { injectGlobal }: Emotion) => {
     const css = injectGlobal;
     css`
         .milkdown .paragraph {

--- a/packages/plugin-cursor/package.json
+++ b/packages/plugin-cursor/package.json
@@ -21,7 +21,6 @@
         "milkdown plugin"
     ],
     "dependencies": {
-        "@emotion/css": "^11.1.3",
         "@milkdown/core": "workspace:*",
         "@milkdown/prose": "workspace:*",
         "@milkdown/utils": "workspace:*",

--- a/packages/plugin-cursor/src/index.ts
+++ b/packages/plugin-cursor/src/index.ts
@@ -1,12 +1,11 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { injectGlobal } from '@emotion/css';
 import { themeToolCtx } from '@milkdown/core';
 import { dropCursor, gapCursor } from '@milkdown/prose';
 import { createPlugin } from '@milkdown/utils';
 
 export const cursor = createPlugin((utils) => {
-    const css = injectGlobal;
-    utils.getStyle((themeTool) => {
+    utils.getStyle((themeTool, { injectGlobal }) => {
+        const css = injectGlobal;
         css`
             /* copy from https://github.com/ProseMirror/prosemirror-gapcursor/blob/master/style/gapcursor.css */
             .ProseMirror-gapcursor {

--- a/packages/plugin-diagram/package.json
+++ b/packages/plugin-diagram/package.json
@@ -23,7 +23,6 @@
         "mermaid"
     ],
     "dependencies": {
-        "@emotion/css": "^11.1.3",
         "@milkdown/utils": "workspace:*",
         "@milkdown/core": "workspace:*",
         "@milkdown/prose": "workspace:*",

--- a/packages/plugin-diagram/src/node.ts
+++ b/packages/plugin-diagram/src/node.ts
@@ -107,7 +107,7 @@ export const diagramNode = createNode<string, Options>((utils, options) => {
             const code = document.createElement('div');
             code.dataset.type = id;
             code.dataset.value = node.attrs.value;
-            if (codeStyle) {
+            if (codeStyle && hideCodeStyle) {
                 code.classList.add(codeStyle, hideCodeStyle);
             }
 
@@ -175,12 +175,16 @@ export const diagramNode = createNode<string, Options>((utils, options) => {
                 },
                 selectNode: () => {
                     if (!view.editable) return;
-                    code.classList.remove(hideCodeStyle);
+                    if (hideCodeStyle) {
+                        code.classList.remove(hideCodeStyle);
+                    }
                     innerEditor.openEditor(code, currentNode);
                     dom.classList.add('ProseMirror-selectednode');
                 },
                 deselectNode: () => {
-                    code.classList.add(hideCodeStyle);
+                    if (hideCodeStyle) {
+                        code.classList.add(hideCodeStyle);
+                    }
                     innerEditor.closeEditor();
                     dom.classList.remove('ProseMirror-selectednode');
                 },

--- a/packages/plugin-diagram/src/style.ts
+++ b/packages/plugin-diagram/src/style.ts
@@ -1,13 +1,12 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
-import { css } from '@emotion/css';
 import { Utils } from '@milkdown/utils';
 
 import { tryRgbToHex } from './utility';
 
 export const getStyle = (utils: Utils) => {
     const codeStyle = utils.getStyle(
-        ({ palette, size, font }) => css`
+        ({ palette, size, font }, { css }) => css`
             color: ${palette('neutral', 0.87)};
             background-color: ${palette('background')};
             border-radius: ${size.radius};
@@ -20,11 +19,13 @@ export const getStyle = (utils: Utils) => {
             }
         `,
     );
-    const hideCodeStyle = css`
-        display: none;
-    `;
+    const hideCodeStyle = utils.getStyle(
+        (_, { css }) => css`
+            display: none;
+        `,
+    );
     const previewPanelStyle = utils.getStyle(
-        () => css`
+        (_, { css }) => css`
             display: flex;
             justify-content: center;
             padding: 1rem 0;

--- a/packages/plugin-emoji/package.json
+++ b/packages/plugin-emoji/package.json
@@ -21,7 +21,6 @@
         "milkdown plugin"
     ],
     "dependencies": {
-        "@emotion/css": "^11.1.3",
         "@joeattardi/emoji-button": "^4.6.0",
         "@milkdown/core": "workspace:*",
         "@milkdown/prose": "workspace:*",

--- a/packages/plugin-emoji/src/filter/style.ts
+++ b/packages/plugin-emoji/src/filter/style.ts
@@ -1,8 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css, cx } from '@emotion/css';
-import type { ThemeTool } from '@milkdown/core';
+import type { Emotion, ThemeTool } from '@milkdown/core';
 
-export const injectStyle = ({ size, mixin, palette, font }: ThemeTool) => {
+export const injectStyle = ({ size, mixin, palette, font }: ThemeTool, { css, cx }: Emotion) => {
     const border = mixin.border?.();
     const shadow = mixin.shadow?.();
 

--- a/packages/plugin-emoji/src/node.ts
+++ b/packages/plugin-emoji/src/node.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { RemarkPlugin } from '@milkdown/core';
 import { InputRule } from '@milkdown/prose';
 import { createNode } from '@milkdown/utils';
@@ -14,7 +13,7 @@ import { twemojiPlugin } from './remark-twemoji';
 
 export const emojiNode = createNode((utils) => {
     const style = utils.getStyle(
-        () => css`
+        (_, { css }) => css`
             display: inline-flex;
             justify-content: center;
             align-items: center;

--- a/packages/plugin-emoji/src/picker.ts
+++ b/packages/plugin-emoji/src/picker.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { injectGlobal } from '@emotion/css';
 import { EmojiButton } from '@joeattardi/emoji-button';
 import { Decoration, DecorationSet, EditorView, Plugin } from '@milkdown/prose';
 import { Utils } from '@milkdown/utils';
@@ -72,7 +71,7 @@ export const picker = (utils: Utils) => {
             if (!parentNode) {
                 throw new Error();
             }
-            utils.getStyle(({ palette, font }) => {
+            utils.getStyle(({ palette, font }, { injectGlobal }) => {
                 const css = injectGlobal;
                 css`
                     .emoji-picker {

--- a/packages/plugin-indent/package.json
+++ b/packages/plugin-indent/package.json
@@ -21,7 +21,6 @@
         "milkdown plugin"
     ],
     "dependencies": {
-        "@emotion/css": "^11.1.3",
         "@milkdown/core": "workspace:*",
         "@milkdown/prose": "workspace:*",
         "@milkdown/utils": "workspace:*",

--- a/packages/plugin-indent/src/index.ts
+++ b/packages/plugin-indent/src/index.ts
@@ -1,6 +1,5 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
-import { injectGlobal } from '@emotion/css';
 import { createCmdKey } from '@milkdown/core';
 import { AllSelection, keymap, TextSelection, Transaction } from '@milkdown/prose';
 import { AtomList, createPlugin, Utils } from '@milkdown/utils';
@@ -28,9 +27,8 @@ const updateIndent = (tr: Transaction, options: Options): Transaction => {
 
 const applyStyle = (options: Options, utils: Utils): void => {
     if (options.type === 'tab') {
-        const css = injectGlobal;
         utils.getStyle(
-            () => css`
+            (_, { injectGlobal }) => injectGlobal`
                 .milkdown {
                     tab-size: ${options.size};
                 }

--- a/packages/plugin-math/package.json
+++ b/packages/plugin-math/package.json
@@ -21,7 +21,6 @@
         "milkdown plugin"
     ],
     "dependencies": {
-        "@emotion/css": "^11.1.3",
         "@types/katex": "^0.11.1",
         "@milkdown/core": "workspace:*",
         "@milkdown/prose": "workspace:*",

--- a/packages/plugin-math/src/math-block/index.ts
+++ b/packages/plugin-math/src/math-block/index.ts
@@ -93,7 +93,7 @@ export const mathBlock = createNode<string, Options>((utils, options) => {
             const code = document.createElement('div');
             code.dataset.type = id;
             code.dataset.value = node.attrs.value;
-            if (codeStyle) {
+            if (codeStyle && hideCodeStyle) {
                 code.classList.add(codeStyle, hideCodeStyle);
             }
 
@@ -155,12 +155,16 @@ export const mathBlock = createNode<string, Options>((utils, options) => {
                 },
                 selectNode: () => {
                     if (!view.editable) return;
-                    code.classList.remove(hideCodeStyle);
+                    if (hideCodeStyle) {
+                        code.classList.remove(hideCodeStyle);
+                    }
                     innerEditor.openEditor(code, currentNode);
                     dom.classList.add('ProseMirror-selectednode');
                 },
                 deselectNode: () => {
-                    code.classList.add(hideCodeStyle);
+                    if (hideCodeStyle) {
+                        code.classList.add(hideCodeStyle);
+                    }
                     innerEditor.closeEditor();
                     dom.classList.remove('ProseMirror-selectednode');
                 },

--- a/packages/plugin-math/src/math-block/style.ts
+++ b/packages/plugin-math/src/math-block/style.ts
@@ -1,11 +1,10 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
-import { css } from '@emotion/css';
 import { Utils } from '@milkdown/utils';
 
 export const getStyle = (utils: Utils) => {
     const codeStyle = utils.getStyle(
-        ({ palette, size, font }) => css`
+        ({ palette, size, font }, { css }) => css`
             color: ${palette('neutral', 0.87)};
             background-color: ${palette('background')};
             border-radius: ${size.radius};
@@ -18,11 +17,13 @@ export const getStyle = (utils: Utils) => {
             }
         `,
     );
-    const hideCodeStyle = css`
-        display: none;
-    `;
+    const hideCodeStyle = utils.getStyle(
+        (_, { css }) => css`
+            display: none;
+        `,
+    );
     const previewPanelStyle = utils.getStyle(
-        () => css`
+        (_, { css }) => css`
             display: flex;
             justify-content: center;
             padding: 1rem 0;

--- a/packages/plugin-math/src/math-inline/index.ts
+++ b/packages/plugin-math/src/math-inline/index.ts
@@ -1,6 +1,5 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey } from '@milkdown/core';
 import { findSelectedNodeOfType, InputRule, NodeSelection } from '@milkdown/prose';
 import { createNode } from '@milkdown/utils';
@@ -20,7 +19,7 @@ export const mathInline = createNode<string, Options>((utils, options) => {
         error: '(error)',
         ...(options?.placeholder ?? {}),
     };
-    const style = utils.getStyle(({ size, palette }) => {
+    const style = utils.getStyle(({ size, palette }, { css }) => {
         return css`
             font-size: unset;
 

--- a/packages/plugin-menu/package.json
+++ b/packages/plugin-menu/package.json
@@ -21,7 +21,6 @@
         "milkdown plugin"
     ],
     "dependencies": {
-        "@emotion/css": "^11.1.3",
         "@milkdown/utils": "workspace:*",
         "@milkdown/core": "workspace:*",
         "@milkdown/prose": "workspace:*",

--- a/packages/plugin-menu/src/button.ts
+++ b/packages/plugin-menu/src/button.ts
@@ -1,6 +1,5 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
-import { css } from '@emotion/css';
 import { CmdKey, commandsCtx, Ctx } from '@milkdown/core';
 import type { Icon } from '@milkdown/design-system';
 import type { EditorView } from '@milkdown/prose';
@@ -18,7 +17,7 @@ export type ButtonConfig<T = any> = {
 } & CommonConfig;
 
 export const button = (utils: Utils, config: ButtonConfig, ctx: Ctx) => {
-    const buttonStyle = utils.getStyle((themeTool) => {
+    const buttonStyle = utils.getStyle((themeTool, { css }) => {
         return css`
             border: 0;
             box-sizing: unset;

--- a/packages/plugin-menu/src/divider.ts
+++ b/packages/plugin-menu/src/divider.ts
@@ -1,6 +1,5 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
-import { css } from '@emotion/css';
 import { Utils } from '@milkdown/utils';
 
 export type DividerConfig = {
@@ -8,7 +7,7 @@ export type DividerConfig = {
     group: HTMLElement[];
 };
 export const divider = (utils: Utils) => {
-    const dividerStyle = utils.getStyle((themeTool) => {
+    const dividerStyle = utils.getStyle((themeTool, { css }) => {
         return css`
             flex-shrink: 0;
             width: ${themeTool.size.lineWidth};

--- a/packages/plugin-menu/src/menubar.ts
+++ b/packages/plugin-menu/src/menubar.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { EditorView } from '@milkdown/prose';
 import { Utils } from '@milkdown/utils';
 
@@ -7,7 +6,7 @@ export const menubar = (utils: Utils, view: EditorView) => {
     const editorWrapperStyle = utils.getStyle((themeTool) => {
         return themeTool.mixin.scrollbar('y');
     });
-    const menuStyle = utils.getStyle((themeTool) => {
+    const menuStyle = utils.getStyle((themeTool, { css }) => {
         const border = themeTool.mixin.border();
         const scrollbar = themeTool.mixin.scrollbar('x');
         const style = css`

--- a/packages/plugin-menu/src/select.ts
+++ b/packages/plugin-menu/src/select.ts
@@ -1,6 +1,5 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
-import { css } from '@emotion/css';
 import { CmdKey, commandsCtx, Ctx } from '@milkdown/core';
 import { EditorView } from '@milkdown/prose';
 import { Utils } from '@milkdown/utils';
@@ -22,7 +21,7 @@ export type SelectConfig<T = any> = {
 } & CommonConfig;
 
 export const select = (utils: Utils, config: SelectConfig, ctx: Ctx, view: EditorView) => {
-    const selectStyle = utils.getStyle((themeTool) => {
+    const selectStyle = utils.getStyle((themeTool, { css }) => {
         return css`
             flex-shrink: 0;
             font-weight: 500;

--- a/packages/plugin-slash/package.json
+++ b/packages/plugin-slash/package.json
@@ -21,7 +21,6 @@
         "milkdown plugin"
     ],
     "dependencies": {
-        "@emotion/css": "^11.1.3",
         "@milkdown/core": "workspace:*",
         "@milkdown/prose": "workspace:*",
         "@milkdown/ctx": "workspace:*",

--- a/packages/plugin-slash/src/prose-plugin/props.ts
+++ b/packages/plugin-slash/src/prose-plugin/props.ts
@@ -1,6 +1,5 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
-import { ThemeTool } from '@milkdown/core';
+import { Emotion, ThemeTool } from '@milkdown/core';
 import { Decoration, DecorationSet, EditorState, EditorView, findParentNode } from '@milkdown/prose';
 import { Utils } from '@milkdown/utils';
 
@@ -8,7 +7,7 @@ import type { Status } from './status';
 
 export type Props = ReturnType<typeof createProps>;
 
-const createEmptyStyle = ({ font, palette }: ThemeTool) => css`
+const createEmptyStyle = ({ font, palette }: ThemeTool, { css }: Emotion) => css`
     position: relative;
     &::before {
         position: absolute;
@@ -23,7 +22,7 @@ const createEmptyStyle = ({ font, palette }: ThemeTool) => css`
     }
 `;
 
-const createSlashStyle = () => css`
+const createSlashStyle = (_: ThemeTool, { css }: Emotion) => css`
     &::before {
         left: 0.5rem;
     }

--- a/packages/plugin-slash/src/style.ts
+++ b/packages/plugin-slash/src/style.ts
@@ -1,8 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
-import { ThemeTool } from '@milkdown/core';
+import { Emotion, ThemeTool } from '@milkdown/core';
 
-const itemStyle = ({ font, palette }: ThemeTool) => {
+const itemStyle = ({ font, palette }: ThemeTool, { css }: Emotion) => {
     return css`
         .slash-dropdown-item {
             display: flex;
@@ -38,9 +37,9 @@ const itemStyle = ({ font, palette }: ThemeTool) => {
             `;
 };
 
-export const injectStyle = (themeTool: ThemeTool) => {
+export const injectStyle = (themeTool: ThemeTool, emotion: Emotion) => {
     const { mixin, size, palette } = themeTool;
-    const style = css`
+    const style = emotion.css`
         width: 20.5rem;
         max-height: 20.5rem;
         overflow-y: auto;
@@ -57,7 +56,7 @@ export const injectStyle = (themeTool: ThemeTool) => {
 
         ${mixin.scrollbar?.()};
 
-        ${itemStyle(themeTool)}
+        ${itemStyle(themeTool, emotion)}
     `;
     return style;
 };

--- a/packages/plugin-tooltip/package.json
+++ b/packages/plugin-tooltip/package.json
@@ -21,7 +21,6 @@
         "milkdown plugin"
     ],
     "dependencies": {
-        "@emotion/css": "^11.1.3",
         "@milkdown/core": "workspace:*",
         "@milkdown/prose": "workspace:*",
         "@milkdown/preset-gfm": "workspace:*",

--- a/packages/plugin-tooltip/src/button-manager/style.ts
+++ b/packages/plugin-tooltip/src/button-manager/style.ts
@@ -1,8 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
-import { ThemeTool } from '@milkdown/core';
+import { Emotion, ThemeTool } from '@milkdown/core';
 
-export const injectStyle = (themeTool: ThemeTool) => {
+export const injectStyle = (themeTool: ThemeTool, { css }: Emotion) => {
     const { palette, mixin, size } = themeTool;
     return css`
         display: inline-flex;

--- a/packages/plugin-tooltip/src/input-manager/style.ts
+++ b/packages/plugin-tooltip/src/input-manager/style.ts
@@ -1,8 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
-import { ThemeTool } from '@milkdown/core';
+import { Emotion, ThemeTool } from '@milkdown/core';
 
-export const injectStyle = (themeTool: ThemeTool) => {
+export const injectStyle = (themeTool: ThemeTool, { css }: Emotion) => {
     const { palette, mixin, size } = themeTool;
 
     return css`

--- a/packages/preset-commonmark/package.json
+++ b/packages/preset-commonmark/package.json
@@ -23,7 +23,6 @@
         "commonmark"
     ],
     "dependencies": {
-        "@emotion/css": "^11.1.3",
         "@milkdown/prose": "workspace:*",
         "@milkdown/core": "workspace:*",
         "@milkdown/design-system": "workspace:*",

--- a/packages/preset-commonmark/src/mark/code-inline.ts
+++ b/packages/preset-commonmark/src/mark/code-inline.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey } from '@milkdown/core';
 import { markRule, toggleMark } from '@milkdown/prose';
 import { createMark, createShortcut } from '@milkdown/utils';
@@ -13,7 +12,7 @@ export const ToggleInlineCode = createCmdKey();
 
 export const codeInline = createMark<Keys>((utils) => {
     const style = utils.getStyle(
-        ({ palette, size, font }) =>
+        ({ palette, size, font }, { css }) =>
             css`
                 background-color: ${palette('neutral')};
                 color: ${palette('background')};

--- a/packages/preset-commonmark/src/mark/link.ts
+++ b/packages/preset-commonmark/src/mark/link.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey, schemaCtx } from '@milkdown/core';
 import { InputRule, Node as ProseNode, TextSelection, toggleMark } from '@milkdown/prose';
 import { createMark } from '@milkdown/utils';
@@ -8,7 +7,7 @@ export const ToggleLink = createCmdKey<string>();
 export const ModifyLink = createCmdKey<string>();
 const id = 'link';
 export const link = createMark((utils) => {
-    const style = utils.getStyle((themeTool) => {
+    const style = utils.getStyle((themeTool, { css }) => {
         const lineColor = themeTool.palette('line');
 
         return css`

--- a/packages/preset-commonmark/src/mark/strong.ts
+++ b/packages/preset-commonmark/src/mark/strong.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey } from '@milkdown/core';
 import { markRule, toggleMark } from '@milkdown/prose';
 import { createMark, createShortcut } from '@milkdown/utils';
@@ -11,7 +10,7 @@ const id = 'strong';
 export const ToggleBold = createCmdKey();
 export const strong = createMark<Keys>((utils) => {
     const style = utils.getStyle(
-        () =>
+        (_, { css }) =>
             css`
                 font-weight: 600;
             `,

--- a/packages/preset-commonmark/src/node/blockquote.ts
+++ b/packages/preset-commonmark/src/node/blockquote.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey } from '@milkdown/core';
 import { wrapIn, wrappingInputRule } from '@milkdown/prose';
 import { createNode, createShortcut } from '@milkdown/utils';
@@ -14,7 +13,7 @@ export const WrapInBlockquote = createCmdKey();
 
 export const blockquote = createNode<Keys>((utils) => {
     const style = utils.getStyle(
-        (themeTool) =>
+        (themeTool, { css }) =>
             css`
                 padding-left: 1.875rem;
                 line-height: 1.75rem;

--- a/packages/preset-commonmark/src/node/code-fence.ts
+++ b/packages/preset-commonmark/src/node/code-fence.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey, themeToolCtx } from '@milkdown/core';
 import { setBlockType, textblockTypeInputRule } from '@milkdown/prose';
 import { createNode, createShortcut } from '@milkdown/utils';
@@ -34,7 +33,7 @@ export const TurnIntoCodeFence = createCmdKey();
 
 const id = 'fence';
 export const codeFence = createNode<Keys, { languageList?: string[] }>((utils, options) => {
-    const style = utils.getStyle(({ palette, mixin, size, font }) => {
+    const style = utils.getStyle(({ palette, mixin, size, font }, { css }) => {
         const { shadow, scrollbar, border } = mixin;
         const { lineWidth, radius } = size;
         return css`

--- a/packages/preset-commonmark/src/node/heading.ts
+++ b/packages/preset-commonmark/src/node/heading.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey } from '@milkdown/core';
 import { setBlockType, textblockTypeInputRule } from '@milkdown/prose';
 import { createNode, createShortcut } from '@milkdown/utils';
@@ -20,31 +19,32 @@ type Keys =
 
 export const TurnIntoHeading = createCmdKey<number>();
 
-export const heading = createNode<Keys>((utils, options) => {
+export const heading = createNode<Keys>((utils) => {
     const id = 'heading';
-    const headingMap: Record<number, string> = {
-        1: css`
-            font-size: 3rem;
-            line-height: 3.5rem;
-        `,
-        2: css`
-            font-size: 2.125rem;
-            line-height: 2.25rem;
-        `,
-        3: css`
-            font-size: 1.5rem;
-            line-height: 1.5rem;
-        `,
-    };
 
     const style = (level: number) =>
-        options?.headless
-            ? null
-            : css`
-                  ${headingMap[level] || ''}
-                  margin: 2.5rem 0 !important;
-                  font-weight: 400;
-              `;
+        utils.getStyle((_, { css }) => {
+            const headingMap: Record<number, string> = {
+                1: css`
+                    font-size: 3rem;
+                    line-height: 3.5rem;
+                `,
+                2: css`
+                    font-size: 2.125rem;
+                    line-height: 2.25rem;
+                `,
+                3: css`
+                    font-size: 1.5rem;
+                    line-height: 1.5rem;
+                `,
+            };
+
+            return css`
+                ${headingMap[level] || ''}
+                margin: 2.5rem 0 !important;
+                font-weight: 400;
+            `;
+        });
 
     return {
         id,

--- a/packages/preset-commonmark/src/node/hr.ts
+++ b/packages/preset-commonmark/src/node/hr.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey, schemaCtx } from '@milkdown/core';
 import { InputRule, Selection } from '@milkdown/prose';
 import { createNode } from '@milkdown/utils';
@@ -8,7 +7,7 @@ const id = 'hr';
 export const InsertHr = createCmdKey<string>();
 export const hr = createNode((utils) => {
     const style = utils.getStyle(
-        (themeTool) => css`
+        (themeTool, { css }) => css`
             height: ${themeTool.size.lineWidth};
             background-color: ${themeTool.palette('line')};
             border-width: 0;

--- a/packages/preset-commonmark/src/node/image.ts
+++ b/packages/preset-commonmark/src/node/image.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey, themeToolCtx } from '@milkdown/core';
 import type { Icon } from '@milkdown/design-system';
 import { findSelectedNodeOfType, InputRule } from '@milkdown/prose';
@@ -25,7 +24,7 @@ export const image = createNode<string, ImageOptions>((utils, options) => {
     };
     const isBlock = options?.isBlock ?? false;
     const containerStyle = utils.getStyle(
-        (themeTool) =>
+        (themeTool, { css }) =>
             css`
                 display: inline-block;
                 position: relative;
@@ -123,7 +122,7 @@ export const image = createNode<string, ImageOptions>((utils, options) => {
     );
 
     const style = utils.getStyle(
-        () =>
+        (_, { css }) =>
             css`
                 display: inline-block;
                 margin: 0 auto;

--- a/packages/preset-commonmark/src/node/list-item.ts
+++ b/packages/preset-commonmark/src/node/list-item.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey } from '@milkdown/core';
 import { liftListItem, sinkListItem, splitListItem, wrappingInputRule } from '@milkdown/prose';
 import { createNode, createShortcut } from '@milkdown/utils';
@@ -16,7 +15,7 @@ export const LiftListItem = createCmdKey();
 
 export const listItem = createNode<Keys>((utils) => {
     const style = utils.getStyle(
-        (themeTool) =>
+        (themeTool, { css }) =>
             css`
                 &,
                 & > * {

--- a/packages/preset-commonmark/src/node/paragraph.ts
+++ b/packages/preset-commonmark/src/node/paragraph.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey } from '@milkdown/core';
 import { setBlockType } from '@milkdown/prose';
 import { createNode, createShortcut } from '@milkdown/utils';
@@ -11,14 +10,14 @@ type Keys = SupportedKeys['Text'];
 export const TurnIntoText = createCmdKey();
 
 const id = 'paragraph';
-export const paragraph = createNode<Keys>((utils, options) => {
-    const style = options?.headless
-        ? null
-        : css`
-              font-size: 1rem;
-              line-height: 1.5;
-              letter-spacing: 0.5px;
-          `;
+export const paragraph = createNode<Keys>((utils) => {
+    const style = utils.getStyle((_, { css }) => {
+        return css`
+            font-size: 1rem;
+            line-height: 1.5;
+            letter-spacing: 0.5px;
+        `;
+    });
 
     return {
         id,

--- a/packages/preset-gfm/package.json
+++ b/packages/preset-gfm/package.json
@@ -23,7 +23,6 @@
         "gfm"
     ],
     "dependencies": {
-        "@emotion/css": "^11.1.3",
         "@milkdown/core": "workspace:*",
         "@milkdown/design-system": "workspace:*",
         "@milkdown/preset-commonmark": "workspace:*",

--- a/packages/preset-gfm/src/strike-through.ts
+++ b/packages/preset-gfm/src/strike-through.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey } from '@milkdown/core';
 import { markRule, toggleMark } from '@milkdown/prose';
 import { createMark, createShortcut } from '@milkdown/utils';
@@ -13,7 +12,7 @@ export const ToggleStrikeThrough = createCmdKey();
 export const strikeThrough = createMark<Keys>((utils) => {
     const id = 'strike_through';
     const style = utils.getStyle(
-        (themeTool) =>
+        (themeTool, { css }) =>
             css`
                 text-decoration-color: ${themeTool.palette('secondary')};
             `,

--- a/packages/preset-gfm/src/table/nodes/style.ts
+++ b/packages/preset-gfm/src/table/nodes/style.ts
@@ -1,8 +1,8 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css, injectGlobal } from '@emotion/css';
+import { Emotion } from '@milkdown/design-system';
 import { Utils } from '@milkdown/utils';
 
-const proseTableStyle = css`
+const proseTableStyle = ({ css }: Emotion) => css`
     /* copy from https://github.com/ProseMirror/prosemirror-tables/blob/master/style/tables.css */
     .ProseMirror .tableWrapper {
         overflow-x: auto;
@@ -48,10 +48,10 @@ const proseTableStyle = css`
 `;
 
 export const injectStyle = (utils: Utils) => {
-    const css = injectGlobal;
-    return utils.getStyle(({ size, palette, mixin }) => {
+    return utils.getStyle(({ size, palette, mixin }, emotion) => {
+        const css = emotion.injectGlobal;
         css`
-            ${proseTableStyle}
+            ${proseTableStyle(emotion)}
 
             .tableWrapper {
                 margin: 0 !important;

--- a/packages/preset-gfm/src/table/operator-plugin/style.ts
+++ b/packages/preset-gfm/src/table/operator-plugin/style.ts
@@ -1,8 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
-import { ThemeTool } from '@milkdown/core';
+import { Emotion, ThemeTool } from '@milkdown/core';
 
-export const injectStyle = ({ size, mixin, palette }: ThemeTool) => css`
+export const injectStyle = ({ size, mixin, palette }: ThemeTool, { css }: Emotion) => css`
     display: inline-flex;
     cursor: pointer;
     z-index: 2;

--- a/packages/preset-gfm/src/task-list-item.ts
+++ b/packages/preset-gfm/src/task-list-item.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
 import { createCmd, createCmdKey, themeToolCtx } from '@milkdown/core';
 import type { Icon } from '@milkdown/design-system';
 import { liftListItem, sinkListItem, splitListItem, wrapIn, wrappingInputRule } from '@milkdown/prose';
@@ -17,7 +16,7 @@ export const TurnIntoTaskList = createCmdKey();
 export const taskListItem = createNode<Keys>((utils) => {
     const id = 'task_list_item';
     const style = utils.getStyle(
-        ({ palette, size }) =>
+        ({ palette, size }, { css }) =>
             css`
                 list-style-type: none;
                 position: relative;

--- a/packages/theme-nord/package.json
+++ b/packages/theme-nord/package.json
@@ -24,7 +24,6 @@
         "nord"
     ],
     "dependencies": {
-        "@emotion/css": "^11.1.3",
         "@milkdown/prose": "workspace:*",
         "@milkdown/core": "workspace:*",
         "@milkdown/design-system": "workspace:*"

--- a/packages/theme-nord/src/index.ts
+++ b/packages/theme-nord/src/index.ts
@@ -1,5 +1,4 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { injectGlobal } from '@emotion/css';
 import { themeFactory } from '@milkdown/core';
 
 import { code, typography } from './font';
@@ -19,35 +18,35 @@ export const size = {
     lineWidth: '1px',
 };
 
-export const nordLight = themeFactory({
+export const nordLight = themeFactory((emotion) => ({
     font,
     size,
+    slots,
     color: lightColor,
-    mixin,
-    slots,
+    mixin: mixin(emotion),
     global: (themeTool) => {
-        const css = injectGlobal;
+        const css = emotion.injectGlobal;
         css`
-            ${view};
-            ${override(themeTool)}
+            ${view(emotion)};
+            ${override(emotion)(themeTool)}
         `;
     },
-});
+}));
 
-export const nordDark = themeFactory({
+export const nordDark = themeFactory((emotion) => ({
     font,
     size,
-    color: darkColor,
-    mixin,
     slots,
+    color: darkColor,
+    mixin: mixin(emotion),
     global: (themeTool) => {
-        const css = injectGlobal;
+        const css = emotion.injectGlobal;
         css`
-            ${view};
-            ${override(themeTool)}
+            ${view(emotion)};
+            ${override(emotion)(themeTool)}
         `;
     },
-});
+}));
 
 const darkMode = Boolean(window.matchMedia?.('(prefers-color-scheme: dark)').matches);
 export const nord = darkMode ? nordDark : nordLight;

--- a/packages/theme-nord/src/mixin.ts
+++ b/packages/theme-nord/src/mixin.ts
@@ -1,50 +1,51 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
-import { ThemePack } from '@milkdown/design-system';
+import { Emotion, ThemePack } from '@milkdown/design-system';
 
-export const mixin: ThemePack['mixin'] = ({ palette, size }) => ({
-    scrollbar: (direction = 'y') => css`
-        scrollbar-width: thin;
-        scrollbar-color: ${palette('secondary', 0.38)} ${palette('secondary', 0.12)};
-        -webkit-overflow-scrolling: touch;
+export const mixin: (emotion: Emotion) => ThemePack['mixin'] =
+    ({ css }) =>
+    ({ palette, size }) => ({
+        scrollbar: (direction = 'y') => css`
+            scrollbar-width: thin;
+            scrollbar-color: ${palette('secondary', 0.38)} ${palette('secondary', 0.12)};
+            -webkit-overflow-scrolling: touch;
 
-        &::-webkit-scrollbar {
-            ${direction === 'y' ? 'width' : 'height'}: 12px;
-            background-color: ${palette('surface')};
-        }
+            &::-webkit-scrollbar {
+                ${direction === 'y' ? 'width' : 'height'}: 12px;
+                background-color: ${palette('surface')};
+            }
 
-        &::-webkit-scrollbar-track {
-            border-radius: 999px;
-            background: ${palette('secondary', 0.12)};
-            border: 4px solid ${palette('surface')};
-        }
+            &::-webkit-scrollbar-track {
+                border-radius: 999px;
+                background: ${palette('secondary', 0.12)};
+                border: 4px solid ${palette('surface')};
+            }
 
-        &::-webkit-scrollbar-thumb {
-            border-radius: 999px;
-            background-color: ${palette('secondary', 0.38)};
-            border: 4px solid ${palette('surface')};
-            background-clip: content-box;
-        }
+            &::-webkit-scrollbar-thumb {
+                border-radius: 999px;
+                background-color: ${palette('secondary', 0.38)};
+                border: 4px solid ${palette('surface')};
+                background-clip: content-box;
+            }
 
-        &::-webkit-scrollbar-thumb:hover {
-            background-color: ${palette('secondary')};
-        }
-    `,
-    shadow: () => {
-        const { lineWidth } = size;
-        return css`
-            box-shadow: 0px ${lineWidth} ${lineWidth} ${palette('shadow', 0.14)},
-                0px 2px ${lineWidth} ${palette('shadow', 0.12)}, 0px ${lineWidth} 3px ${palette('shadow', 0.2)};
-        `;
-    },
-    border: (direction) => {
-        if (!direction) {
+            &::-webkit-scrollbar-thumb:hover {
+                background-color: ${palette('secondary')};
+            }
+        `,
+        shadow: () => {
+            const { lineWidth } = size;
             return css`
-                border: ${size.lineWidth} solid ${palette('line')};
+                box-shadow: 0px ${lineWidth} ${lineWidth} ${palette('shadow', 0.14)},
+                    0px 2px ${lineWidth} ${palette('shadow', 0.12)}, 0px ${lineWidth} 3px ${palette('shadow', 0.2)};
             `;
-        }
-        return css`
-            ${`border-${direction}`}: ${size.lineWidth} solid ${palette('line')};
-        `;
-    },
-});
+        },
+        border: (direction) => {
+            if (!direction) {
+                return css`
+                    border: ${size.lineWidth} solid ${palette('line')};
+                `;
+            }
+            return css`
+                ${`border-${direction}`}: ${size.lineWidth} solid ${palette('line')};
+            `;
+        },
+    });

--- a/packages/theme-nord/src/override.ts
+++ b/packages/theme-nord/src/override.ts
@@ -1,48 +1,50 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
-import { css } from '@emotion/css';
-import { ThemeTool } from '@milkdown/design-system';
+import { Emotion, ThemeTool } from '@milkdown/design-system';
 
-export const override = ({ palette, mixin, size, font }: ThemeTool) => css`
-    .milkdown {
-        color: ${palette('neutral', 0.87)};
-        background: ${palette('surface')};
+export const override =
+    ({ css }: Emotion) =>
+    ({ palette, mixin, size, font }: ThemeTool) =>
+        css`
+            .milkdown {
+                color: ${palette('neutral', 0.87)};
+                background: ${palette('surface')};
 
-        position: relative;
-        font-family: ${font.typography};
-        margin-left: auto;
-        margin-right: auto;
-        ${mixin.shadow?.()};
-        box-sizing: border-box;
-        ${mixin.scrollbar?.()};
+                position: relative;
+                font-family: ${font.typography};
+                margin-left: auto;
+                margin-right: auto;
+                ${mixin.shadow?.()};
+                box-sizing: border-box;
+                ${mixin.scrollbar?.()};
 
-        .editor {
-            padding: 3.125rem 1.25rem;
-            outline: none;
-            & > * {
-                margin: 1.875rem 0;
+                .editor {
+                    padding: 3.125rem 1.25rem;
+                    outline: none;
+                    & > * {
+                        margin: 1.875rem 0;
+                    }
+
+                    @media only screen and (min-width: 72rem) {
+                        max-width: 57.375rem;
+                        padding: 3.125rem 7.25rem;
+                    }
+                }
+
+                .ProseMirror-selectednode {
+                    outline: ${size.lineWidth} solid ${palette('line')};
+                }
+
+                li.ProseMirror-selectednode {
+                    outline: none;
+                }
+
+                li.ProseMirror-selectednode::after {
+                    ${mixin.border?.()};
+                }
+
+                & ::selection {
+                    background: ${palette('secondary', 0.38)};
+                }
             }
-
-            @media only screen and (min-width: 72rem) {
-                max-width: 57.375rem;
-                padding: 3.125rem 7.25rem;
-            }
-        }
-
-        .ProseMirror-selectednode {
-            outline: ${size.lineWidth} solid ${palette('line')};
-        }
-
-        li.ProseMirror-selectednode {
-            outline: none;
-        }
-
-        li.ProseMirror-selectednode::after {
-            ${mixin.border?.()};
-        }
-
-        & ::selection {
-            background: ${palette('secondary', 0.38)};
-        }
-    }
-`;
+        `;

--- a/packages/theme-nord/src/view.ts
+++ b/packages/theme-nord/src/view.ts
@@ -1,7 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { css } from '@emotion/css';
+import { Emotion } from '@milkdown/design-system';
 
-export const view = css`
+export const view = ({ css }: Emotion) => css`
     /* copy from https://github.com/ProseMirror/@milkdown/prose/blob/master/style/prosemirror.css */
     .ProseMirror {
         position: relative;

--- a/packages/utils/src/factory/common.ts
+++ b/packages/utils/src/factory/common.ts
@@ -4,6 +4,7 @@ import {
     CmdKey,
     commandsCtx,
     Ctx,
+    emotionCtx,
     InitReady,
     inputRulesCtx,
     prosePluginsCtx,
@@ -38,10 +39,11 @@ export const createShortcut = <T>(commandKey: CmdKey<T>, defaultKey: string, arg
 export const getUtils = <Options extends UnknownRecord>(ctx: Ctx, options?: Options): Utils => {
     try {
         const themeTool = ctx.get(themeToolCtx);
+        const emotion = ctx.get(emotionCtx);
 
         return {
             getClassName: getClassName(options?.className as undefined),
-            getStyle: (style) => (options?.headless ? '' : (style(themeTool) as string | undefined)),
+            getStyle: (style) => (options?.headless ? '' : (style(themeTool, emotion) as string | undefined)),
             themeTool,
         };
     } catch {

--- a/packages/utils/src/factory/create-mark.ts
+++ b/packages/utils/src/factory/create-mark.ts
@@ -1,6 +1,15 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
-import { Ctx, MarkSchema, marksCtx, MilkdownPlugin, schemaCtx, SchemaReady, viewCtx } from '@milkdown/core';
+import {
+    ConfigReady,
+    Ctx,
+    MarkSchema,
+    marksCtx,
+    MilkdownPlugin,
+    schemaCtx,
+    SchemaReady,
+    viewCtx,
+} from '@milkdown/core';
 import { MarkType, MarkViewFactory, ViewFactory } from '@milkdown/prose';
 
 import { Factory, UnknownRecord, WithExtend } from '../types';
@@ -28,6 +37,7 @@ export const createMark = <SupportedKeys extends string = string, Options extend
             (options): MilkdownPlugin =>
                 () =>
                 async (ctx) => {
+                    await ctx.wait(ConfigReady);
                     const utils = getUtils(ctx, options);
 
                     const plugin = factory(utils, options);

--- a/packages/utils/src/factory/create-node.ts
+++ b/packages/utils/src/factory/create-node.ts
@@ -1,6 +1,15 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
-import { Ctx, MilkdownPlugin, NodeSchema, nodesCtx, schemaCtx, SchemaReady, viewCtx } from '@milkdown/core';
+import {
+    ConfigReady,
+    Ctx,
+    MilkdownPlugin,
+    NodeSchema,
+    nodesCtx,
+    schemaCtx,
+    SchemaReady,
+    viewCtx,
+} from '@milkdown/core';
 import { NodeType, NodeViewFactory, ViewFactory } from '@milkdown/prose';
 
 import { Factory, UnknownRecord, WithExtend } from '../types';
@@ -28,6 +37,7 @@ export const createNode = <SupportedKeys extends string = string, Options extend
             (options): MilkdownPlugin =>
                 () =>
                 async (ctx) => {
+                    await ctx.wait(ConfigReady);
                     const utils = getUtils(ctx, options);
 
                     const plugin = factory(utils, options);

--- a/packages/utils/src/factory/create-plugin.ts
+++ b/packages/utils/src/factory/create-plugin.ts
@@ -1,6 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
 import {
+    ConfigReady,
     Ctx,
     MarkSchema,
     marksCtx,
@@ -56,6 +57,7 @@ export const createPlugin = <
             (options): MilkdownPlugin =>
                 () =>
                 async (ctx) => {
+                    await ctx.wait(ConfigReady);
                     const utils = getUtils(ctx, options);
 
                     const plugin = factory(utils, options);

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,11 +1,11 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import type { Attrs, CmdKey, MilkdownPlugin, ThemeTool } from '@milkdown/core';
+import type { Attrs, CmdKey, Emotion, MilkdownPlugin, ThemeTool } from '@milkdown/core';
 import { CmdTuple, Ctx, RemarkPlugin } from '@milkdown/core';
 import { InputRule, Plugin, ViewFactory } from '@milkdown/prose';
 
 export type Utils = {
     readonly getClassName: (attrs: Attrs, ...defaultValue: (string | null | undefined)[]) => string;
-    readonly getStyle: (style: (themeTool: ThemeTool) => string | void) => string | undefined;
+    readonly getStyle: (style: (themeTool: ThemeTool, emotion: Emotion) => string | void) => string | undefined;
     readonly themeTool: ThemeTool;
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,9 +286,11 @@ importers:
 
   packages/design-system:
     specifiers:
+      '@emotion/cache': ^11.7.1
       '@emotion/css': ^11.1.3
       tslib: ^2.3.1
     dependencies:
+      '@emotion/cache': 11.7.1
       '@emotion/css': 11.7.1
       tslib: 2.3.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,7 +312,6 @@ importers:
 
   packages/plugin-collaborative:
     specifiers:
-      '@emotion/css': ^11.1.3
       '@milkdown/core': workspace:*
       '@milkdown/prose': workspace:*
       '@milkdown/utils': workspace:*
@@ -321,7 +320,6 @@ importers:
       y-protocols: ^1.0.5
       yjs: ^13.5.11
     dependencies:
-      '@emotion/css': 11.7.1
       '@milkdown/core': link:../core
       '@milkdown/prose': link:../prose
       '@milkdown/utils': link:../utils
@@ -332,13 +330,11 @@ importers:
 
   packages/plugin-cursor:
     specifiers:
-      '@emotion/css': ^11.1.3
       '@milkdown/core': workspace:*
       '@milkdown/prose': workspace:*
       '@milkdown/utils': workspace:*
       tslib: ^2.3.1
     dependencies:
-      '@emotion/css': 11.7.1
       '@milkdown/core': link:../core
       '@milkdown/prose': link:../prose
       '@milkdown/utils': link:../utils
@@ -346,7 +342,6 @@ importers:
 
   packages/plugin-diagram:
     specifiers:
-      '@emotion/css': ^11.1.3
       '@milkdown/core': workspace:*
       '@milkdown/prose': workspace:*
       '@milkdown/utils': workspace:*
@@ -356,7 +351,6 @@ importers:
       tslib: ^2.3.1
       unist-util-visit: 4.0.0
     dependencies:
-      '@emotion/css': 11.7.1
       '@milkdown/core': link:../core
       '@milkdown/prose': link:../prose
       '@milkdown/utils': link:../utils
@@ -368,7 +362,6 @@ importers:
 
   packages/plugin-emoji:
     specifiers:
-      '@emotion/css': ^11.1.3
       '@joeattardi/emoji-button': ^4.6.0
       '@milkdown/core': workspace:*
       '@milkdown/prose': workspace:*
@@ -382,7 +375,6 @@ importers:
       twemoji: ^13.1.0
       unist-util-visit: 4.0.0
     dependencies:
-      '@emotion/css': 11.7.1
       '@joeattardi/emoji-button': 4.6.2
       '@milkdown/core': link:../core
       '@milkdown/prose': link:../prose
@@ -410,13 +402,11 @@ importers:
 
   packages/plugin-indent:
     specifiers:
-      '@emotion/css': ^11.1.3
       '@milkdown/core': workspace:*
       '@milkdown/prose': workspace:*
       '@milkdown/utils': workspace:*
       tslib: ^2.3.1
     dependencies:
-      '@emotion/css': 11.7.1
       '@milkdown/core': link:../core
       '@milkdown/prose': link:../prose
       '@milkdown/utils': link:../utils
@@ -436,7 +426,6 @@ importers:
 
   packages/plugin-math:
     specifiers:
-      '@emotion/css': ^11.1.3
       '@milkdown/core': workspace:*
       '@milkdown/prose': workspace:*
       '@milkdown/utils': workspace:*
@@ -445,7 +434,6 @@ importers:
       remark-math: ^5.1.0
       tslib: ^2.3.1
     dependencies:
-      '@emotion/css': 11.7.1
       '@milkdown/core': link:../core
       '@milkdown/prose': link:../prose
       '@milkdown/utils': link:../utils
@@ -456,7 +444,6 @@ importers:
 
   packages/plugin-menu:
     specifiers:
-      '@emotion/css': ^11.1.3
       '@milkdown/core': workspace:*
       '@milkdown/design-system': workspace:*
       '@milkdown/plugin-history': workspace:*
@@ -465,7 +452,6 @@ importers:
       '@milkdown/utils': workspace:*
       tslib: ^2.3.1
     dependencies:
-      '@emotion/css': 11.7.1
       '@milkdown/core': link:../core
       '@milkdown/design-system': link:../design-system
       '@milkdown/plugin-history': link:../plugin-history
@@ -492,7 +478,6 @@ importers:
 
   packages/plugin-slash:
     specifiers:
-      '@emotion/css': ^11.1.3
       '@milkdown/core': workspace:*
       '@milkdown/ctx': workspace:*
       '@milkdown/design-system': workspace:*
@@ -502,7 +487,6 @@ importers:
       smooth-scroll-into-view-if-needed: ^1.1.32
       tslib: ^2.3.1
     dependencies:
-      '@emotion/css': 11.7.1
       '@milkdown/core': link:../core
       '@milkdown/ctx': link:../ctx
       '@milkdown/design-system': link:../design-system
@@ -514,7 +498,6 @@ importers:
 
   packages/plugin-tooltip:
     specifiers:
-      '@emotion/css': ^11.1.3
       '@milkdown/core': workspace:*
       '@milkdown/design-system': workspace:*
       '@milkdown/plugin-math': workspace:*
@@ -523,7 +506,6 @@ importers:
       '@milkdown/utils': workspace:*
       tslib: ^2.3.1
     dependencies:
-      '@emotion/css': 11.7.1
       '@milkdown/core': link:../core
       '@milkdown/design-system': link:../design-system
       '@milkdown/plugin-math': link:../plugin-math
@@ -546,7 +528,6 @@ importers:
 
   packages/preset-commonmark:
     specifiers:
-      '@emotion/css': ^11.1.3
       '@milkdown/core': workspace:*
       '@milkdown/design-system': workspace:*
       '@milkdown/prose': workspace:*
@@ -554,7 +535,6 @@ importers:
       remark-inline-links: ^6.0.0
       tslib: ^2.3.1
     dependencies:
-      '@emotion/css': 11.7.1
       '@milkdown/core': link:../core
       '@milkdown/design-system': link:../design-system
       '@milkdown/prose': link:../prose
@@ -564,7 +544,6 @@ importers:
 
   packages/preset-gfm:
     specifiers:
-      '@emotion/css': ^11.1.3
       '@milkdown/core': workspace:*
       '@milkdown/design-system': workspace:*
       '@milkdown/preset-commonmark': workspace:*
@@ -573,7 +552,6 @@ importers:
       remark-gfm: ^3.0.0
       tslib: ^2.3.1
     dependencies:
-      '@emotion/css': 11.7.1
       '@milkdown/core': link:../core
       '@milkdown/design-system': link:../design-system
       '@milkdown/preset-commonmark': link:../preset-commonmark
@@ -663,12 +641,10 @@ importers:
 
   packages/theme-nord:
     specifiers:
-      '@emotion/css': ^11.1.3
       '@milkdown/core': workspace:*
       '@milkdown/design-system': workspace:*
       '@milkdown/prose': workspace:*
     dependencies:
-      '@emotion/css': 11.7.1
       '@milkdown/core': link:../core
       '@milkdown/design-system': link:../design-system
       '@milkdown/prose': link:../prose
@@ -1699,7 +1675,7 @@ packages:
   /@emotion/css/11.7.1:
     resolution: {integrity: sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': '*'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -8970,9 +8946,6 @@ packages:
   /y-prosemirror/1.0.14_y-protocols@1.0.5+yjs@13.5.24:
     resolution: {integrity: sha512-fJQn/XT+z/gks9sd64eB+Mf1UQP0d5SHQ8RwbrzIwYFW+FgU/nx8/hJm+nrBAoO9azHOY5aDeoffeLmOFXLD9w==}
     peerDependencies:
-      prosemirror-model: ^1.7.1
-      prosemirror-state: ^1.2.3
-      prosemirror-view: ^1.9.10
       y-protocols: ^1.0.1
       yjs: ^13.3.2
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,8 @@ const resolvePath = (str: string) => path.resolve(__dirname, str);
 export const external = [
     'tslib',
     '@emotion/css',
+    '@emotion/cache',
+    '@emotion/sheet',
     'remark',
     'vue',
     'react',


### PR DESCRIPTION
✅ Closes: [233](https://github.com/Saul-Mirone/milkdown/issues/233)

```typescript
import { emotionConfigCtx } from '@milkdown/core';

const editor = Editor.make()
    .config((ctx) => {
        ctx.set(emotionConfigCtx, {
            key: 'milkdown-instance',
            container: document.querySelector('#app') as HTMLElement,
        });
    })
// ....
```