### PR TITLE
Downcase emoji searches

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "test": "pnpm test:doc && pnpm test:lint && pnpm test:tsc && pnpm test:unit",
         "test:unit": "vitest",
         "test:tsc": "pnpm --filter=./packages run tsc",
-        "test:lint": "eslint **/{src,gh-pages,examples}/**/*.{js,ts,tsx}",
+        "test:lint": "eslint \"**/{src,gh-pages,examples}/**/*.{js,ts,tsx}\"",
         "test:doc": "prettier --check \"**/*.md\"",
         "test:e2e": "pnpm run start:test --filter @milkdown/e2e",
         "format": "lint-staged",

--- a/packages/plugin-emoji/src/filter/helper.ts
+++ b/packages/plugin-emoji/src/filter/helper.ts
@@ -18,8 +18,9 @@ export const checkTrigger = (
     const { state } = view;
     const $from = state.doc.resolve(from);
     if ($from.parent.type.spec.code) return false;
-    const textBefore =
-        $from.parent.textBetween(Math.max(0, $from.parentOffset - 10), $from.parentOffset, undefined, '\ufffc') + text;
+    const textBefore = (
+        $from.parent.textBetween(Math.max(0, $from.parentOffset - 10), $from.parentOffset, undefined, '\ufffc') + text
+    ).toLowerCase();
     if (full.test(textBefore)) {
         return false;
     }


### PR DESCRIPTION
Hello! I've been loving milkdown. 

To get a little further into the code, I thought it'd be a useful pedagogical exercise for me to send the world's smallest diff to support emoji typeahead syntax with uppercase inputs. 

While writing docs with milkdown, I've often wanted to add emoji to headers. Since headers are often written in titlecase, I've found myself typing emoji with uppercase letters (:HI ... ). I think the emoji typeahead should match these strings. Just now while typing this message, I notice that Github.com's markdown parser handles uppercase emojis :) 

After I made my commit, I went to run the tests and got the following stacktrace:

```
> eslint **/{src,gh-pages,examples}/**/*.{js,ts,tsx}


Oops! Something went wrong! :(

ESLint: 8.7.0

No files matching the pattern "**/src/**/*.js" were found.
Please check for typing mistakes in the pattern.
```
So I added escaped doublequotes around the lint test glob, which permits the linter to run on Monterey. I'm happy to unstack these commits if you prefer!

There were some typing tests that failed but those should be unrelated to this diff. 

If there's anything else I can do to improve this please just say the word. Either way, thanks for this excellent work.