### PR TITLE
feat: autofocus tooltip input & submit on Enter key

### DIFF
--- a/packages/plugin-tooltip/src/input-manager/index.ts
+++ b/packages/plugin-tooltip/src/input-manager/index.ts
@@ -25,13 +25,22 @@ export const createInputManager = (inputMap: InputMap, utils: Utils) => {
         if (!binding || !inputCommand) return;
         inputCommand(e);
     };
+    const onKeydown = (e: KeyboardEvent) => {
+        if (!inputCommand) return;
+        if ('key' in e && e.key === 'Enter') {
+            inputCommand(e);
+            div.classList.add('hide');
+        }
+    };
 
     input.addEventListener('input', onInput);
+    input.addEventListener('keydown', onKeydown);
     button.addEventListener('mousedown', onClick);
 
     return {
         destroy: () => {
             input.removeEventListener('input', onInput);
+            input.removeEventListener('keydown', onKeydown);
             div.removeEventListener('mousedown', onClick);
             div.remove();
         },

--- a/packages/plugin-tooltip/src/utility/input.ts
+++ b/packages/plugin-tooltip/src/utility/input.ts
@@ -7,14 +7,16 @@ import { elementIsTag } from './element';
 
 export const modifyLink =
     (ctx: Ctx): Event2Command =>
-    (e) => {
+    (e: Event | KeyboardEvent) => {
         const { target } = e;
         if (!(target instanceof HTMLElement)) {
             return () => true;
         }
         if (elementIsTag(target, 'input')) {
-            target.focus();
-            return () => false;
+            if (!('key' in e) || e.key !== 'Enter') {
+                target.focus();
+                return () => false;
+            }
         }
         const parent = target.parentNode;
         if (!parent) return () => false;
@@ -43,14 +45,16 @@ export const modifyInlineMath =
 
 export const modifyImage =
     (ctx: Ctx): Event2Command =>
-    (e) => {
+    (e: Event | KeyboardEvent) => {
         const { target } = e;
         if (!(target instanceof HTMLElement)) {
             return () => true;
         }
         if (elementIsTag(target, 'input')) {
-            target.focus();
-            return () => false;
+            if (!('key' in e) || e.key !== 'Enter') {
+                target.focus();
+                return () => false;
+            }
         }
         const parent = target.parentNode;
         if (!parent) return () => false;
@@ -66,6 +70,7 @@ export const updateLinkView: Updater = (view, $) => {
     const { firstChild, lastElementChild } = $;
     if (!(firstChild instanceof HTMLInputElement) || !(lastElementChild instanceof HTMLButtonElement)) return;
 
+    firstChild.focus();
     const { selection } = view.state;
     let node: ProseNode | undefined;
     view.state.doc.nodesBetween(selection.from, selection.to, (n) => {


### PR DESCRIPTION
This MR seeks to expedite the process of setting link and image source values through the tooltip input.

In the current demo, one needs to click four times to create a link:

1) Click a link button (in the menu or tooltip) to add a mark to some text
2) Click the text that now has a link mark
3) Click the input so that one can start typing the link href
4) Click the submit button to persist the link text and close the modal

![old](https://user-images.githubusercontent.com/4801116/151706442-c7a84600-cd19-4e9e-b77a-ff757052756a.gif)

This MR reduces the number of clicks required to two:

1) Click a link button (in the menu or tooltip) to add a mark to some text
2) Click the text that now has a link mark

![new](https://user-images.githubusercontent.com/4801116/151706464-545ff9ea-f119-442b-9d95-54c505a69f83.gif)

I'd like to make that second click unnecessary as well, but thought I'd send these changes in and make sure this looks alright before moving to that next step...

Any thoughts or feedback is welcome!

P.S. That new prosemirror dev tool in the demo looks awesome!