### PR TITLE
Stop clobbering view options in the clipboard plugin

### DIFF
--- a/packages/plugin-clipboard/src/clipboard.ts
+++ b/packages/plugin-clipboard/src/clipboard.ts
@@ -28,6 +28,7 @@ export const clipboardPlugin = createPlugin(() => {
 
             // Set editable props for https://github.com/Saul-Mirone/milkdown/issues/190
             ctx.update(editorViewOptionsCtx, (prev) => ({
+                ...prev,
                 editable: prev.editable ?? (() => true),
             }));
 


### PR DESCRIPTION
I was switching to use Milkdown in one of my projects when I discovered that the `ViewOptions` I intended to pass to `ProseMirror` were not being respected.

E.g., I was passing in a `dispatchTransaction` prop:

```
ctx.set(
  editorViewOptionsCtx,
  {
    editable: () => !readOnly,
    dispatchTransaction(tr) {...}
  },
);
```

but it was never making it to the editor.

Putting a `console.log` in `core/internal-plugin/editor-view.ts` confirmed that the prop was missing.

The culprit was the clipboard plugin -- it updates the view options without preserving the existing options.

---

**Note:** I think a better approach might be to change the `Ctx` API to add a `ctx.merge` method. Merge would merge the new state with the old state. This will prevent plugin authors from making this same mistake again.

lmk what you think and I can submit a pull-request with an update to the context API instead.