### PR TITLE
fix: 🐛 diagram is not loaded in doc.

### DIFF
--- a/gh-pages/component/MilkdownEditor/editor.ts
+++ b/gh-pages/component/MilkdownEditor/editor.ts
@@ -54,7 +54,7 @@ export const createEditor = (
         .use(history)
         .use(cursor)
         .use(prism)
-        .use(diagram)
+        .use(diagram())
         .use(tooltip)
         .use(math)
         .use(emoji)


### PR DESCRIPTION
Noted that I haven't sync gh-page with latest mermaid API change, I made a commit to fix this.

I tried to use git rebase to clean up my fork, but used git push -f. I don't know whether if I'm doing right. Please review it, and sorry for bothering you once again. 🙏