### PR TITLE
feat: add new property 'extra' to ThemeTool

### DIFF
--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -18,7 +18,7 @@ export const injectVar = (themePack: ThemePack, emotion: Emotion) => {
 };
 
 export const pack2Tool = (themePack: ThemePack): ThemeTool => {
-    const { font, size = {}, mixin: _mixin, slots: _slots, global } = themePack;
+    const { font, size = {}, mixin: _mixin, slots: _slots, global, extra: _extra } = themePack;
 
     const palette = (key: Color, alpha = 1) => {
         return `rgba(var(--${key}), ${alpha})`;
@@ -61,9 +61,14 @@ export const pack2Tool = (themePack: ThemePack): ThemeTool => {
         slots,
     };
 
-    global?.(tool);
+    const extraTool = {
+        ...tool,
+        ..._extra?.(tool)
+    };
 
-    return tool;
+    global?.(extraTool);
+
+    return extraTool;
 };
 
 export type { Emotion, Options } from './emotion';

--- a/packages/design-system/src/types.ts
+++ b/packages/design-system/src/types.ts
@@ -60,6 +60,7 @@ export type ThemePack = {
     size?: PR<Size>;
     mixin?: (utils: Omit<ThemeTool, 'slots' | 'global' | 'mixin'>) => Partial<MixinFactory>;
     slots?: (utils: Omit<ThemeTool, 'slots' | 'global'>) => Partial<Slots>;
+    extra?: (utils: Omit<ThemeTool, 'extra' | 'global'>) => Record<string, any>;
     global?: (utils: Omit<ThemeTool, 'global'>) => void;
 };
 
@@ -69,4 +70,5 @@ export type ThemeTool = {
     slots: Slots;
     font: Record<Font, string>;
     size: Record<Size, string>;
+    extra?: Record<string, any>;
 };


### PR DESCRIPTION
I use milk down in my project. I need more colors than palette provides. And I want to add line-spacing to theme pack too.
And maybe more things need to be put into theme pack.
So I introduce a 'extra' property into ThemeTool. I use it this way:

Define in theme pack:
![image](https://user-images.githubusercontent.com/9511090/172057490-4e7499a4-653a-46bf-86de-0a95818cae61.png)

Use in plugins:
![image](https://user-images.githubusercontent.com/9511090/172057613-5e54e319-5ffe-4f12-8fe0-90b24400b921.png)
