### PR TITLE
feat: make a plugin to render all directive as text to avoid parse error when use remark-directive

### DIFF
--- a/gh-pages/pages/official-plugins/plugin-directive-fallback/index.md
+++ b/gh-pages/pages/official-plugins/plugin-directive-fallback/index.md
@@ -1,0 +1,62 @@
+# @milkdown/plugin-directive-fallback
+
+let's say if you make a plugin like this.
+
+```typescript
+
+schema: () => ({
+    // ...
+    parseMarkdown: {
+        match: (node) => node.type === 'textDirective' && node.name === 'iframe',
+        runner: (state, node, type) => {
+            state.addNode(type, { src: (node.attributes as { src: string }).src });
+        },
+    },
+}),
+
+```
+
+```typescript
+import { Editor } from '@milkdown/core';
+import { commonmark } from '@milkdown/preset-commonmark';
+import { nord } from '@milkdown/theme-nord';
+
+import { directiveWithFallback } from '@milkdown/plugin-directive-fallback';
+
+const defaultValue = `# Hello milkdown :::abc{.class#id} content ::: `;
+
+Editor.make()
+    .Editor.make()
+    .use(commonmark)
+    .use(iframePlugin)
+    .config((ctx) => {
+        ctx.set(defaultValueCtx, defaultValue);
+    })
+    .create();
+```
+
+If you don't use plugin-directive-fallback.
+
+The editor crash when you run it with some other directive;
+
+It render all directive as text to avoid parse error when use remark-directive;
+
+```typescript
+import { Editor } from '@milkdown/core';
+import { commonmark } from '@milkdown/preset-commonmark';
+import { nord } from '@milkdown/theme-nord';
+
+import { directiveWithFallback } from '@milkdown/plugin-directive-fallback';
+
+const defaultValue = `# Hello milkdown :::abc{.class#id} content ::: `;
+
+Editor.make()
+    .Editor.make()
+    .use(commonmark)
+    .use(iframePlugin)
+    .use(directiveWithFallback)
+    .config((ctx) => {
+        ctx.set(defaultValueCtx, defaultValue);
+    })
+    .create();
+```

--- a/gh-pages/route/page-config.ts
+++ b/gh-pages/route/page-config.ts
@@ -49,6 +49,7 @@ export const config: ConfigItem[] = [
             'plugin-menu',
             'plugin-indent',
             'plugin-trailing',
+            'plugin-directive-fallback',
             'plugin-emoji',
             'plugin-collaborative',
             'plugin-upload',

--- a/gh-pages/route/page-dict.ts
+++ b/gh-pages/route/page-dict.ts
@@ -444,6 +444,13 @@ export const titleDict: Dict = new Map([
         },
     ],
     [
+        'plugin-directive-fallback',
+        {
+            en: 'plugin-directive-fallback',
+            'zh-hans': 'plugin-directive-fallback',
+        },
+    ],
+    [
         'theme-nord',
         {
             en: 'Theme Nord',

--- a/packages/plugin-directive-fallback/CHANGELOG.md
+++ b/packages/plugin-directive-fallback/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @milkdown/plugin-directive-fallback
+
+## 6.2.0
+
+### Minor Changes
+
+-   26afcdaf: New react and vue API, custom heading id, prosemirror upgrade, and async composable API.
+
+### Patch Changes
+
+-   Updated dependencies [26afcdaf]
+    -   @milkdown/utils@6.2.0

--- a/packages/plugin-directive-fallback/README.md
+++ b/packages/plugin-directive-fallback/README.md
@@ -1,0 +1,11 @@
+# @milkdown/plugin-directive-fallback
+
+The directive-fallback plugin of [milkdown](https://milkdown.dev/).
+
+# Official Documentation
+
+Documentation can be found on the [Milkdown website](https://milkdown.dev/plugin-directive-fallback).
+
+# License
+
+Milkdown is open sourced software licensed under [MIT license](https://github.com/Saul-Mirone/milkdown/blob/main/LICENSE).

--- a/packages/plugin-directive-fallback/package.json
+++ b/packages/plugin-directive-fallback/package.json
@@ -1,0 +1,61 @@
+{
+    "name": "@milkdown/plugin-directive-fallback",
+    "version": "6.2.0",
+    "type": "module",
+    "main": "./lib/index.es.js",
+    "types": "./lib/index.d.ts",
+    "sideEffects": false,
+    "license": "MIT",
+    "scripts": {
+        "start": "concurrently -n es,dts \"vite build --watch\"  \"tsc --emitDeclarationOnly --watch\"",
+        "test": "vitest",
+        "tsc": "tsc --noEmit && echo",
+        "build": "tsc --emitDeclarationOnly && vite build"
+    },
+    "files": [
+        "lib",
+        "src"
+    ],
+    "keywords": [
+        "milkdown",
+        "milkdown plugin"
+    ],
+    "devDependencies": {
+        "@milkdown/core": "workspace:*",
+        "@milkdown/utils": "workspace:*",
+        "remark-directive": "^2.0.1",
+        "@milkdown/prose": "workspace:*"
+    },
+    "peerDependencies": {
+        "@milkdown/core": "^6.0.1",
+        "@milkdown/prose": "^6.0.1"
+    },
+    "dependencies": {
+        "@milkdown/utils": "workspace:*",
+        "tslib": "^2.3.1"
+    },
+    "nx": {
+        "targets": {
+            "build": {
+                "outputs": [
+                    "packages/plugin-directive-fallback/lib"
+                ],
+                "dependsOn": [
+                    {
+                        "target": "build",
+                        "projects": "dependencies"
+                    }
+                ]
+            },
+            "tsc": {
+                "outputs": [],
+                "dependsOn": [
+                    {
+                        "target": "build",
+                        "projects": "dependencies"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/packages/plugin-directive-fallback/src/containerDirective.ts
+++ b/packages/plugin-directive-fallback/src/containerDirective.ts
@@ -1,0 +1,48 @@
+/* Copyright 2021, Milkdown by Mirone. */
+// import { SupportedKeys } from '@milkdown/preset-commonmark';
+import { NodeType } from '@milkdown/prose/model';
+import { createNode } from '@milkdown/utils';
+
+import { attributesToString } from './utils';
+// type Keys = SupportedKeys['notice'];
+
+const id = 'directiveContainerFallback';
+
+export const directiveContainerNode = createNode(() => {
+    return {
+        id,
+        schema: () => ({
+            attrs: {
+                name: {
+                    default: '',
+                },
+                attrString: {
+                    default: '',
+                },
+            },
+            content: 'block+',
+            group: 'block',
+            parseMarkdown: {
+                match: ({ type }) => type === 'containerDirective',
+                runner: (state, node) => {
+                    state.openNode(state.schema.nodes['paragraph'] as NodeType);
+                    state.addText(
+                        `:::${node['name']}${attributesToString(
+                            node['attributes'] as Record<string, string>,
+                            node.children,
+                        )}`,
+                    );
+                    state.closeNode();
+                    state.next(node.children);
+                    state.openNode(state.schema.nodes['paragraph'] as NodeType);
+                    state.addText(':::');
+                    state.closeNode();
+                },
+            },
+            toMarkdown: {
+                match: () => false,
+                runner: () => null,
+            },
+        }),
+    };
+});

--- a/packages/plugin-directive-fallback/src/directive.ts
+++ b/packages/plugin-directive-fallback/src/directive.ts
@@ -1,0 +1,13 @@
+/* Copyright 2021, Milkdown by Mirone. */
+// import { SupportedKeys } from '@milkdown/preset-commonmark';
+import '@milkdown/prose/model';
+
+import { RemarkPlugin } from '@milkdown/core';
+import { createPlugin } from '@milkdown/utils';
+import directive from 'remark-directive';
+
+export const remarkDirective = createPlugin(() => {
+    return {
+        remarkPlugins: () => [directive as RemarkPlugin],
+    };
+});

--- a/packages/plugin-directive-fallback/src/index.ts
+++ b/packages/plugin-directive-fallback/src/index.ts
@@ -1,0 +1,15 @@
+/* Copyright 2021, Milkdown by Mirone. */
+// import { SupportedKeys } from '@milkdown/preset-commonmark';
+import { AtomList } from '@milkdown/utils';
+
+import { directiveContainerNode } from './containerDirective';
+import { remarkDirective } from './directive';
+import { directiveLeafNode } from './leafDirective';
+import { directiveTextNode } from './textDirective';
+
+export const directiveFallback = AtomList.create([
+    directiveContainerNode(),
+    directiveTextNode(),
+    directiveLeafNode(),
+    remarkDirective(),
+]);

--- a/packages/plugin-directive-fallback/src/leafDirective.ts
+++ b/packages/plugin-directive-fallback/src/leafDirective.ts
@@ -1,0 +1,45 @@
+/* Copyright 2021, Milkdown by Mirone. */
+// import { SupportedKeys } from '@milkdown/preset-commonmark';
+import { NodeType } from '@milkdown/prose/model';
+import { createNode } from '@milkdown/utils';
+
+// type Keys = SupportedKeys['notice'];
+import { attributesToString } from './utils';
+
+const id = 'directiveLeafFallback';
+
+export const directiveLeafNode = createNode(() => {
+    return {
+        id,
+        schema: () => ({
+            attrs: {
+                name: {
+                    default: '',
+                },
+                attrString: {
+                    default: '',
+                },
+            },
+            content: 'block',
+            group: 'block',
+            parseMarkdown: {
+                match: ({ type }) => type === 'leafDirective',
+                runner: (state, node) => {
+                    state.openNode(state.schema.nodes['paragraph'] as NodeType);
+                    state.addText(
+                        `::${node['name']}${attributesToString(
+                            node['attributes'] as Record<string, string>,
+                            node.children,
+                            true,
+                        )}`,
+                    );
+                    state.closeNode();
+                },
+            },
+            toMarkdown: {
+                match: () => false,
+                runner: () => null,
+            },
+        }),
+    };
+});

--- a/packages/plugin-directive-fallback/src/textDirective.ts
+++ b/packages/plugin-directive-fallback/src/textDirective.ts
@@ -1,0 +1,44 @@
+/* Copyright 2021, Milkdown by Mirone. */
+// import { SupportedKeys } from '@milkdown/preset-commonmark';
+import { createNode } from '@milkdown/utils';
+
+import { attributesToString } from './utils';
+
+const id = 'directiveTextFallback';
+
+export const directiveTextNode = createNode(() => {
+    return {
+        id,
+        schema: () => ({
+            attrs: {
+                name: {
+                    default: '',
+                },
+                type: {
+                    default: '',
+                },
+                attrString: {
+                    default: '',
+                },
+            },
+            group: 'inline',
+            inline: true,
+            parseMarkdown: {
+                match: ({ type }) => type === 'textDirective',
+                runner: (state, node) => {
+                    state.addText(
+                        `:${node['name']}${attributesToString(
+                            node['attributes'] as Record<string, string>,
+                            node.children,
+                        )}`,
+                    );
+                },
+            },
+
+            toMarkdown: {
+                match: () => false,
+                runner: () => null,
+            },
+        }),
+    };
+});

--- a/packages/plugin-directive-fallback/src/utils.ts
+++ b/packages/plugin-directive-fallback/src/utils.ts
@@ -1,0 +1,42 @@
+/* Copyright 2021, Milkdown by Mirone. */
+import { MarkdownNode } from '@milkdown/core';
+
+export const attributesToString = (
+    attrs: Record<string, string>,
+    children?: MarkdownNode[],
+    isLeaf?: boolean,
+): string => {
+    let d = '';
+    const labelIndex = children
+        ? children.findIndex((v) => {
+              const data = v ? v.data || {} : {};
+              return data['directiveLabel'];
+          })
+        : -1;
+    const label = children ? children[labelIndex] : null;
+    if (label && label.children) {
+        d += `[${label.children.map((v) => v['value']).join(' ')}]`;
+        children && children.splice(labelIndex, 1);
+    }
+    if (isLeaf && children && children.length) {
+        d += `[${children.map((v) => v['value']).join(' ')}]`;
+        children && children.splice(labelIndex, 1);
+    }
+    if (attrs['id']) {
+        d += '#' + attrs['id'];
+    }
+    if (attrs['class']) {
+        const c = attrs['class'].split(' ');
+        d += '.' + c.join('.');
+    }
+    for (const key in attrs) {
+        if (key === 'id') {
+            continue;
+        }
+        if (key === 'class') {
+            continue;
+        }
+        d += ` ${key}="${attrs[key]}"`;
+    }
+    return d;
+};

--- a/packages/plugin-directive-fallback/tsconfig.json
+++ b/packages/plugin-directive-fallback/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "lib"
+    },
+    "include": ["src"]
+}

--- a/packages/plugin-directive-fallback/vite.config.ts
+++ b/packages/plugin-directive-fallback/vite.config.ts
@@ -1,0 +1,4 @@
+/* Copyright 2021, Milkdown by Mirone. */
+import { pluginViteConfig } from '../../vite.config';
+
+export default pluginViteConfig('plugin-directive-fallback');


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

## Summary

let's say if you make a plugin like this.

```typescript
schema: () => ({
    // ...
    parseMarkdown: {
        match: (node) => node.type === 'textDirective' && node.name === 'iframe',
        runner: (state, node, type) => {
            state.addNode(type, { src: (node.attributes as { src: string }).src });
        },
    },
}),
```

```typescript
import { Editor } from '@milkdown/core';
import { commonmark } from '@milkdown/preset-commonmark';
import { nord } from '@milkdown/theme-nord';
import { directiveWithFallback } from '@milkdown/plugin-directive-fallback';
const defaultValue = `# Hello milkdown :::abc{.class#id} content ::: `;
Editor.make()
    .Editor.make()
    .use(commonmark)
    .use(iframePlugin)
    .config((ctx) => {
        ctx.set(defaultValueCtx, defaultValue);
    })
    .create();
```

If you don't use plugin-directive-fallback.

The editor crash when you run it with some other directive;

It render all directive as text to avoid parse error when use remark-directive;

```typescript
import { Editor } from '@milkdown/core';
import { commonmark } from '@milkdown/preset-commonmark';
import { nord } from '@milkdown/theme-nord';
import { directiveWithFallback } from '@milkdown/plugin-directive-fallback';
const defaultValue = `# Hello milkdown :::abc{.class#id} content ::: `;
Editor.make()
    .Editor.make()
    .use(commonmark)
    .use(iframePlugin)
    .use(directiveWithFallback)
    .config((ctx) => {
        ctx.set(defaultValueCtx, defaultValue);
    })
    .create();
```
Every thing is ok . 

## How did you test this change?

manual test
