### PR TITLE
fix: 🐛 multiple editor timing event dispatch

### DIFF
--- a/packages/ctx/src/timing/timing.ts
+++ b/packages/ctx/src/timing/timing.ts
@@ -23,6 +23,7 @@ export const createTimer = (name: string, timeout = 3000): Timer => {
                     }
                     if (e.detail.id === data) {
                         removeEventListener(name, listener);
+                        e.stopImmediatePropagation();
                         resolve();
                     }
                 };

--- a/packages/ctx/src/timing/timing.ts
+++ b/packages/ctx/src/timing/timing.ts
@@ -22,6 +22,7 @@ export const createTimer = (name: string, timeout = 3000): Timer => {
                         return;
                     }
                     if (e.detail.id === data) {
+                        removeEventListener(name, listener);
                         resolve();
                     }
                 };
@@ -29,7 +30,7 @@ export const createTimer = (name: string, timeout = 3000): Timer => {
                     reject(`Timing ${name} timeout.`);
                     removeEventListener(name, listener);
                 }, timeout);
-                addEventListener(name, listener, { once: true });
+                addEventListener(name, listener);
             }));
         timing.done = () => {
             const event = new CustomEvent(name, { detail: { id: data } });


### PR DESCRIPTION
## Summary
For multiple editor, event will dispatch to all listeners, which remove other editors' listener.

## How did you test this change?
Run an example.
