### PR TITLE
feat: 🎸 list and listItem support attr spread

### DIFF
--- a/packages/preset-commonmark/src/node/heading.ts
+++ b/packages/preset-commonmark/src/node/heading.ts
@@ -119,7 +119,7 @@ const headingHashPlugin = (ctx: Ctx, type: NodeType, utils: ThemeUtils): Plugin 
             },
             apply: (tr) => {
                 const view = ctx.get(editorViewCtx);
-                if (!view.hasFocus || !view.editable) return DecorationSet.empty;
+                if (!view.hasFocus() || !view.editable) return DecorationSet.empty;
 
                 const { $from } = tr.selection;
                 const node = $from.node();

--- a/packages/preset-commonmark/src/node/list-item.ts
+++ b/packages/preset-commonmark/src/node/list-item.ts
@@ -79,6 +79,9 @@ export const listItem = createNode<Keys>((utils) => ({
             listType: {
                 default: 'bullet',
             },
+            spread: {
+                default: 'true',
+            },
         },
         defining: true,
         parseDOM: [
@@ -91,6 +94,7 @@ export const listItem = createNode<Keys>((utils) => ({
                     return {
                         label: dom.dataset['label'],
                         listType: dom.dataset['list-type'],
+                        spread: dom.dataset['spread'],
                     };
                 },
                 contentElement: 'div.list-item_body',
@@ -104,6 +108,7 @@ export const listItem = createNode<Keys>((utils) => ({
                     class: utils.getClassName(node.attrs, 'list-item'),
                     'data-label': node.attrs['label'],
                     'data-list-type': node.attrs['listType'],
+                    'data-spread': node.attrs['spread'],
                 },
                 ['div', { class: utils.getClassName(node.attrs, 'list-item_label') }, node.attrs['label']],
                 ['div', { class: utils.getClassName(node.attrs, 'list-item_body') }, 0],
@@ -114,7 +119,8 @@ export const listItem = createNode<Keys>((utils) => ({
             runner: (state, node, type) => {
                 const label = node['label'] != null ? `${node['label']}.` : '•';
                 const listType = node['label'] != null ? 'ordered' : 'bullet';
-                state.openNode(type, { label, listType });
+                const spread = node['spread'] != null ? `${node['spread']}` : 'true';
+                state.openNode(type, { label, listType, spread });
                 state.next(node.children);
                 state.closeNode();
             },
@@ -122,7 +128,7 @@ export const listItem = createNode<Keys>((utils) => ({
         toMarkdown: {
             match: (node) => node.type.name === id,
             runner: (state, node) => {
-                state.openNode('listItem');
+                state.openNode('listItem', undefined, { spread: node.attrs['spread'] === 'true' });
                 state.next(node.content);
                 state.closeNode();
             },

--- a/packages/preset-commonmark/src/node/ordered-list.ts
+++ b/packages/preset-commonmark/src/node/ordered-list.ts
@@ -21,6 +21,9 @@ export const orderedList = createNode<Keys>((utils) => ({
             order: {
                 default: 1,
             },
+            spread: {
+                default: 'true',
+            },
         },
         parseDOM: [
             {
@@ -29,7 +32,10 @@ export const orderedList = createNode<Keys>((utils) => ({
                     if (!(dom instanceof HTMLElement)) {
                         throw expectDomTypeError(dom);
                     }
-                    return { order: dom.hasAttribute('start') ? Number(dom.getAttribute('start')) : 1 };
+                    return {
+                        spread: dom.dataset['spread'],
+                        order: dom.hasAttribute('start') ? Number(dom.getAttribute('start')) : 1,
+                    };
                 },
             },
         ],
@@ -37,6 +43,7 @@ export const orderedList = createNode<Keys>((utils) => ({
             'ol',
             {
                 ...(node.attrs['order'] === 1 ? {} : node.attrs['order']),
+                'data-spread': node.attrs['spread'],
                 class: utils.getClassName(node.attrs, 'ordered-list'),
             },
             0,
@@ -44,13 +51,14 @@ export const orderedList = createNode<Keys>((utils) => ({
         parseMarkdown: {
             match: ({ type, ordered }) => type === 'list' && !!ordered,
             runner: (state, node, type) => {
-                state.openNode(type).next(node.children).closeNode();
+                const spread = node['spread'] != null ? `${node['spread']}` : 'true';
+                state.openNode(type, { spread }).next(node.children).closeNode();
             },
         },
         toMarkdown: {
             match: (node) => node.type.name === id,
             runner: (state, node) => {
-                state.openNode('list', undefined, { ordered: true, start: 1 });
+                state.openNode('list', undefined, { ordered: true, start: 1, spread: node.attrs['spread'] === 'true' });
                 state.next(node.content);
                 state.closeNode();
             },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

列表编辑之后列表项之间会多出来一行。

```
1. 1
2. 2
```

会变成

```
1. 1

2. 2
```

remark 的 ast 有一个 `spread` 属性，经过 milkdown 转换后丢失了，所以存储一下 `spread` 属性，生成 ast 时带上 `spread` 属性，就不会多出来一行。如果原来 markdown 文档的列表有空行，转换后也可以保持原状。

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
