### PR TITLE
ci: 🎡 change e2e to nx cache

### DIFF
--- a/.github/workflows/ci-for-pr.yml
+++ b/.github/workflows/ci-for-pr.yml
@@ -46,15 +46,6 @@ jobs:
             - name: run e2e cache
               run: pnpm test:e2e:cache
 
-            - name: run cypress
-              uses: cypress-io/github-action@v2
-              with:
-                  install: false
-                  start: pnpm --filter=@milkdown/e2e start
-                  command: pnpm --filter=@milkdown/e2e test
-                  wait-on: 'http://localhost:7000'
-                  browser: chrome
-
             - run: pnpm exec nx-cloud stop-all-agents
               if: ${{ always() }}
 

--- a/.github/workflows/ci-for-pr.yml
+++ b/.github/workflows/ci-for-pr.yml
@@ -43,8 +43,14 @@ jobs:
             - name: run test
               run: pnpm test
 
-            - name: run e2e cache
-              run: pnpm test:e2e:cache
+            - name: run cypress
+              uses: cypress-io/github-action@v2
+              with:
+                  install: false
+                  start: pnpm --filter=@milkdown/e2e start
+                  command: pnpm test:e2e:cache
+                  wait-on: 'http://localhost:7000'
+                  browser: chrome
 
             - run: pnpm exec nx-cloud stop-all-agents
               if: ${{ always() }}

--- a/.github/workflows/ci-for-pr.yml
+++ b/.github/workflows/ci-for-pr.yml
@@ -41,8 +41,10 @@ jobs:
               run: pnpm build:cache
 
             - name: run test
-              run: |
-                  pnpm test
+              run: pnpm test
+
+            - name: run e2e cache
+              run: pnpm test:e2e:cache
 
             - name: run cypress
               uses: cypress-io/github-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,15 +43,12 @@ jobs:
             - name: run test
               run: pnpm test
 
-            - name: run e2e cache
-              run: pnpm test:e2e:cache
-
             - name: run cypress
               uses: cypress-io/github-action@v2
               with:
                   install: false
                   start: pnpm --filter=@milkdown/e2e start
-                  command: pnpm --filter=@milkdown/e2e test
+                  command: pnpm test:e2e:cache
                   wait-on: 'http://localhost:7000'
                   browser: chrome
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,10 @@ jobs:
               run: pnpm build:cache
 
             - name: run test
-              run: |
-                  pnpm test
+              run: pnpm test
+
+            - name: run e2e cache
+              run: pnpm test:e2e:cache
 
             - name: run cypress
               uses: cypress-io/github-action@v2

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,11 +6,11 @@
         "start": "vite",
         "build": "vite build",
         "serve": "vite preview --port 7000",
-        "setup": "nx build e2e && pnpm serve",
+        "setup": "pnpm serve",
         "test": "cypress run",
         "test:verbose": "cypress open",
-        "start:test": "start-server-and-test setup http-get://localhost:7000 test",
         "e2e": "start-server-and-test setup http-get://localhost:7000 test",
+        "start:test": "start-server-and-test setup http-get://localhost:7000 test",
         "start:test:verbose": "start-server-and-test setup http-get://localhost:7000 test:verbose"
     },
     "files": [

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,9 +7,9 @@
         "build": "vite build",
         "serve": "vite preview --port 7000",
         "setup": "pnpm serve",
+        "e2e": "start-server-and-test setup http-get://localhost:7000 test",
         "test": "cypress run",
         "test:verbose": "cypress open",
-        "e2e": "start-server-and-test setup http-get://localhost:7000 test",
         "start:test": "start-server-and-test setup http-get://localhost:7000 test",
         "start:test:verbose": "start-server-and-test setup http-get://localhost:7000 test:verbose"
     },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,7 +7,7 @@
         "build": "vite build",
         "serve": "vite preview --port 7000",
         "setup": "pnpm serve",
-        "e2e": "start-server-and-test setup http-get://localhost:7000 test",
+        "e2e": "nx test e2e",
         "test": "cypress run",
         "test:verbose": "cypress open",
         "start:test": "start-server-and-test setup http-get://localhost:7000 test",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -43,13 +43,7 @@
                     "production": {
                         "devServerTarget": "e2e:serve"
                     }
-                },
-                "dependsOn": [
-                    {
-                        "target": "build",
-                        "projects": "dependencies"
-                    }
-                ]
+                }
             },
             "build": {
                 "outputs": [


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Make e2e as a nx command.
