### PR TITLE
fix: 🐛 export diagramNode for config

### DIFF
--- a/packages/plugin-diagram/src/index.ts
+++ b/packages/plugin-diagram/src/index.ts
@@ -9,4 +9,4 @@ export * from './remark-mermaid';
 export const diagram = AtomList.create([diagramNode()]);
 
 export type { Options } from './node';
-export { TurnIntoDiagram } from './node';
+export { diagramNode, TurnIntoDiagram } from './node';


### PR DESCRIPTION
## Summary

Fix missing export.

