### PR TITLE
fix: 🐛 plugin-block menu position wrong

### DIFF
--- a/e2e/cypress/e2e/preset-commonmark/input.cy.ts
+++ b/e2e/cypress/e2e/preset-commonmark/input.cy.ts
@@ -160,8 +160,8 @@ describe('input:', () => {
             });
 
             it('is a bold', () => {
-                cy.get('.editor').type('The lunatic is "**on the grass**"');
-                cy.get('.editor').get('.strong').should('have.text', 'on the grass');
+                cy.get('.editor').type('The lunatic is "**B**"');
+                cy.get('.editor').get('.strong').should('have.text', 'B');
                 cy.window().then((win) => {
                     cy.wrap(win.__getMarkdown__()).snapshot();
                     return;
@@ -189,8 +189,8 @@ describe('input:', () => {
             });
 
             it('is an italic', () => {
-                cy.get('.editor').type('The lunatic is "_on the grass_"');
-                cy.get('.editor').get('.em').should('have.text', 'on the grass');
+                cy.get('.editor').type('The lunatic is "_I_"');
+                cy.get('.editor').get('.em').should('have.text', 'I');
                 cy.window().then((win) => {
                     cy.wrap(win.__getMarkdown__()).snapshot();
                     return;

--- a/e2e/snapshots.js
+++ b/e2e/snapshots.js
@@ -42,7 +42,7 @@ module.exports = {
           "1": "The lunatic is \\*\\*\"on the grass\\*\\*\n"
         },
         "is a bold": {
-          "1": "The lunatic is \"**on the grass**\"\n"
+          "1": "The lunatic is \"**B**\"\n"
         }
       },
       "italic": {
@@ -51,7 +51,7 @@ module.exports = {
           "1": "The lunatic is *on the grass*\n"
         },
         "is an italic": {
-          "1": "The lunatic is \"*on the grass*\"\n"
+          "1": "The lunatic is \"*I*\"\n"
         },
         "not an italic": {
           "1": "The lunatic is \\_\"on the grass\\_\n"

--- a/packages/plugin-block/src/block-menu-dom.ts
+++ b/packages/plugin-block/src/block-menu-dom.ts
@@ -155,7 +155,7 @@ export class BlockMenuDOM {
         this.dom$.removeEventListener('click', this.#clickMenu);
     }
 
-    render(view: EditorView, el: HTMLElement) {
+    render(view: EditorView, targetNodeRect: DOMRect) {
         const root = view.dom.parentElement;
         if (!root) {
             throw missingRootElement();
@@ -182,7 +182,6 @@ export class BlockMenuDOM {
             return;
         }
 
-        const targetNodeRect = (<HTMLElement>el).getBoundingClientRect();
         const rootRect = root.getBoundingClientRect();
         const handleRect = this.#blockHandle.dom$.getBoundingClientRect();
         const menuRect = this.dom$.getBoundingClientRect();

--- a/packages/plugin-block/src/block-service.ts
+++ b/packages/plugin-block/src/block-service.ts
@@ -39,6 +39,7 @@ export class BlockService {
     };
     #activeSelection: null | Selection = null;
     #active: null | ActiveNode = null;
+    #activeDOMRect: undefined | DOMRect = undefined;
 
     #dragging = false;
     #ctx: Ctx;
@@ -72,15 +73,16 @@ export class BlockService {
     }
 
     #handleMouseDown = () => {
+        this.#activeDOMRect = this.#active?.el.getBoundingClientRect();
         this.#createSelection();
     };
 
     #handleMouseUp = () => {
         if (!this.#dragging) {
             requestAnimationFrame(() => {
-                if (!this.#active) return;
+                if (!this.#activeDOMRect) return;
                 this.blockMenu$.toggle();
-                this.blockMenu$.render(this.#view, this.#active.el);
+                this.blockMenu$.render(this.#view, this.#activeDOMRect);
                 this.#view.focus();
             });
 

--- a/packages/preset-commonmark/src/mark/em.ts
+++ b/packages/preset-commonmark/src/mark/em.ts
@@ -37,8 +37,8 @@ export const em = createMark<Keys>((utils) => ({
         },
     }),
     inputRules: (markType) => [
-        markRule(/(?:^|\b|\s|[^\w`*_])((?:\*)(\w(?:[^*]+))(?:\*))$/, markType),
-        markRule(/(?:^|\s|[^\w`*_])((?:_)(\w(?:[^_]+))(?:_))$/, markType),
+        markRule(/(?:^|\s|[^\w`*_])((?:_)(\w[^_]*)(?:_))$/, markType),
+        markRule(/(?:^|\s|[^\w`*_])((?:\*)(\w[^*]*)(?:\*))$/, markType),
     ],
     commands: (markType) => [createCmd(ToggleItalic, () => toggleMark(markType))],
     shortcuts: {

--- a/packages/preset-commonmark/src/mark/strong.ts
+++ b/packages/preset-commonmark/src/mark/strong.ts
@@ -35,8 +35,8 @@ export const strong = createMark<Keys>((utils) => {
             },
         }),
         inputRules: (markType) => [
-            markRule(/(?:^|\s|[^\w`])((?:__)(\w(?:[^__]+))(?:__))$/, markType),
-            markRule(/(?:^|\b|\s|[^\w`])((?:\*\*)(\w(?:[^*]+))(?:\*\*))$/, markType),
+            markRule(/(?:^|\s|[^\w`])((?:__)(\w[^_]*)(?:__))$/, markType),
+            markRule(/(?:^|\s|[^\w`])((?:\*\*)(\w[^*]*)(?:\*\*))$/, markType),
         ],
         commands: (markType) => [createCmd(ToggleBold, () => toggleMark(markType))],
         shortcuts: {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

![image](https://user-images.githubusercontent.com/1715916/186625686-e42cd3bd-a191-4a0a-8761-ac6af97d761a.png)

有时在空行前触发块级菜单，鼠标按下后slash插件会重新渲染p标签，鼠标抬起后#target已脱离文档，所以改为鼠标按下时缓存#targetDOMRect

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
