### PR TITLE
Inline sync plugin

### DIFF
--- a/e2e/cypress/e2e/preset-commonmark/input.cy.ts
+++ b/e2e/cypress/e2e/preset-commonmark/input.cy.ts
@@ -227,7 +227,8 @@ describe('input:', () => {
             });
 
             it('inline code with * and _', () => {
-                cy.get('.editor').type('The lunatic is `**_on the grass_**`');
+                cy.get('.editor').type('The lunatic is `****`');
+                cy.get('.editor').type('{leftArrow}').type('{leftArrow}').type('_on the grass_');
                 cy.get('.editor').get('.code-inline').should('have.text', '**_on the grass_**');
                 cy.window().then((win) => {
                     cy.wrap(win.__getMarkdown__()).snapshot();

--- a/e2e/cypress/e2e/preset-commonmark/shortcut.cy.ts
+++ b/e2e/cypress/e2e/preset-commonmark/shortcut.cy.ts
@@ -112,11 +112,6 @@ describe('input:', () => {
             cy.get('.strong').should('have.text', 'The lunatic is on the grass');
             cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`);
             cy.get('.strong').should('not.exist');
-            cy.get('.editor').type('{backspace}');
-            cy.get('.editor').type('The lunatic is ');
-            cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+b}`);
-            cy.get('.editor').type('on the grass');
-            cy.get('.strong').should('have.text', 'on the grass');
         });
 
         it('italic', () => {
@@ -126,11 +121,6 @@ describe('input:', () => {
             cy.get('.em').should('have.text', 'The lunatic is on the grass');
             cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+i}`);
             cy.get('.em').should('not.exist');
-            cy.get('.editor').type('{backspace}');
-            cy.get('.editor').type('The lunatic is ');
-            cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+i}`);
-            cy.get('.editor').type('on the grass');
-            cy.get('.em').should('have.text', 'on the grass');
         });
 
         it('inline code', () => {

--- a/e2e/cypress/e2e/preset-gfm/shortcut.cy.ts
+++ b/e2e/cypress/e2e/preset-gfm/shortcut.cy.ts
@@ -26,10 +26,5 @@ describe('shortcut:', () => {
         cy.get('.strike-through').should('have.text', 'The lunatic is on the grass');
         cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+alt+x}`);
         cy.get('.strike-through').should('not.exist');
-        cy.get('.editor').type('{backspace}');
-        cy.get('.editor').type('The lunatic is ');
-        cy.get('.editor').type(`{${isMac ? 'cmd' : 'ctrl'}+alt+x}`);
-        cy.get('.editor').type('on the grass');
-        cy.get('.strike-through').should('have.text', 'on the grass');
     });
 });

--- a/e2e/snapshots.js
+++ b/e2e/snapshots.js
@@ -29,7 +29,7 @@ module.exports = {
         "1": "1.  The lunatic is on the grass\n2.  The lunatic is in the hell\n\n    *   The lunatic is on the grass\n    *   The lunatic is in the hell\n"
       },
       "hr": {
-        "1": "***\n\n"
+        "1": "***\n"
       }
     },
     "mark:": {

--- a/e2e/snapshots.js
+++ b/e2e/snapshots.js
@@ -17,9 +17,6 @@ module.exports = {
       "ordered list": {
         "1": "1.  list item 1\n2.  list item 2\n\n    1.  sub list item 1\n    2.  sub list item 2\n3.  list item 3\n"
       },
-      "hr": {
-        "1": "***\n"
-      },
       "image": {
         "invalid image": {
           "1": "![image](invalidUrl)\n"
@@ -30,6 +27,9 @@ module.exports = {
       },
       "list": {
         "1": "1.  The lunatic is on the grass\n2.  The lunatic is in the hell\n\n    *   The lunatic is on the grass\n    *   The lunatic is in the hell\n"
+      },
+      "hr": {
+        "1": "***\n\n"
       }
     },
     "mark:": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "test:lint": "eslint \"**/{src,website,examples}/**/*.{js,ts,tsx}\"",
         "test:doc": "prettier --check \"**/*.md\"",
         "test:e2e": "pnpm --filter=@milkdown/e2e run start:test",
+        "test:e2e:verbose": "pnpm --filter=@milkdown/e2e run start:test:verbose",
         "test:e2e:cache": "nx e2e e2e",
         "format": "lint-staged",
         "watch": "pnpm --filter=./packages --parallel run start",

--- a/packages/plugin-math/src/math-inline/index.ts
+++ b/packages/plugin-math/src/math-inline/index.ts
@@ -3,7 +3,6 @@
 import { Color, commandsCtx, createCmd, createCmdKey, ThemeColor, ThemeInputChipType, ThemeSize } from '@milkdown/core';
 import { expectDomTypeError } from '@milkdown/exception';
 import { findSelectedNodeOfType } from '@milkdown/prose';
-import { InputRule } from '@milkdown/prose/inputrules';
 import { NodeSelection, Plugin, PluginKey } from '@milkdown/prose/state';
 import { EditorView } from '@milkdown/prose/view';
 import { createNode } from '@milkdown/utils';
@@ -150,27 +149,6 @@ export const mathInline = createNode<string, Options>((utils, options) => {
                 },
             };
         },
-        inputRules: (nodeType) => [
-            new InputRule(/(?:\$)([^$]+)(?:\$)$/, (state, match, start, end) => {
-                const $start = state.doc.resolve(start);
-                const index = $start.index();
-                const $end = state.doc.resolve(end);
-                if (!$start.parent.canReplaceWith(index, $end.index(), nodeType)) {
-                    return null;
-                }
-                const value = match[1] ?? '';
-                return state.tr.replaceRangeWith(
-                    start,
-                    end,
-                    nodeType.create(
-                        {
-                            value,
-                        },
-                        nodeType.schema.text(value),
-                    ),
-                );
-            }),
-        ],
         prosePlugins: (type, ctx) => {
             return [
                 new Plugin({

--- a/packages/plugin-tooltip/src/item.ts
+++ b/packages/plugin-tooltip/src/item.ts
@@ -28,12 +28,7 @@ export type ButtonItem = {
     enable: Pred;
 };
 
-export const createToggleIcon = (
-    icon: Icon,
-    onClick: string,
-    mark: MarkType | undefined,
-    disableForMark: MarkType | undefined,
-): Item => ({
+export const createToggleIcon = (icon: Icon, onClick: string, mark?: MarkType, disableForMark?: MarkType): Item => ({
     icon,
     onClick,
     isHidden: () => (view: EditorView) => isTextAndNotHasMark(view.state, disableForMark),
@@ -44,11 +39,11 @@ export const createToggleIcon = (
 export const defaultButtons = (ctx: Ctx) => {
     const marks = ctx.get(schemaCtx).marks;
     return [
-        createToggleIcon('bold', 'ToggleBold', marks['strong'], marks['code_inline']),
-        createToggleIcon('italic', 'ToggleItalic', marks['em'], marks['code_inline']),
-        createToggleIcon('strikeThrough', 'ToggleStrikeThrough', marks['strike_through'], marks['code_inline']),
-        createToggleIcon('code', 'ToggleInlineCode', marks['code_inline'], marks['link']),
-        createToggleIcon('link', 'ToggleLink', marks['link'], marks['code_inline']),
+        createToggleIcon('bold', 'ToggleBold', marks['strong']),
+        createToggleIcon('italic', 'ToggleItalic', marks['em']),
+        createToggleIcon('strikeThrough', 'ToggleStrikeThrough', marks['strike_through']),
+        createToggleIcon('code', 'ToggleInlineCode', marks['code_inline']),
+        createToggleIcon('link', 'ToggleLink', marks['link']),
     ];
 };
 

--- a/packages/preset-commonmark/src/mark/code-inline.ts
+++ b/packages/preset-commonmark/src/mark/code-inline.ts
@@ -1,6 +1,5 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import { createCmd, createCmdKey } from '@milkdown/core';
-import { markRule } from '@milkdown/prose';
 import { toggleMark } from '@milkdown/prose/commands';
 import { createMark, createShortcut } from '@milkdown/utils';
 
@@ -35,7 +34,6 @@ export const codeInline = createMark<Keys>((utils) => {
                 },
             },
         }),
-        // inputRules: (markType) => [markRule(/(?:^|[^`])(`([^`]+)`)$/, markType)],
         commands: (markType) => [createCmd(ToggleInlineCode, () => toggleMark(markType))],
         shortcuts: {
             [SupportedKeys.CodeInline]: createShortcut(ToggleInlineCode, 'Mod-e'),

--- a/packages/preset-commonmark/src/mark/code-inline.ts
+++ b/packages/preset-commonmark/src/mark/code-inline.ts
@@ -35,7 +35,7 @@ export const codeInline = createMark<Keys>((utils) => {
                 },
             },
         }),
-        inputRules: (markType) => [markRule(/(?:^|[^`])(`([^`]+)`)$/, markType)],
+        // inputRules: (markType) => [markRule(/(?:^|[^`])(`([^`]+)`)$/, markType)],
         commands: (markType) => [createCmd(ToggleInlineCode, () => toggleMark(markType))],
         shortcuts: {
             [SupportedKeys.CodeInline]: createShortcut(ToggleInlineCode, 'Mod-e'),

--- a/packages/preset-commonmark/src/mark/em.ts
+++ b/packages/preset-commonmark/src/mark/em.ts
@@ -37,8 +37,8 @@ export const em = createMark<Keys>((utils) => ({
         },
     }),
     inputRules: (markType) => [
-        markRule(/(?:^|[^_])(_([^_]+)_)$/, markType),
-        markRule(/(?:^|[^*])(\*([^*]+)\*)$/, markType),
+        // markRule(/(?:^|[^_])(_([^_]+)_)$/, markType),
+        // markRule(/(?:^|[^*])(\*([^*]+)\*)$/, markType),
     ],
     commands: (markType) => [createCmd(ToggleItalic, () => toggleMark(markType))],
     shortcuts: {

--- a/packages/preset-commonmark/src/mark/em.ts
+++ b/packages/preset-commonmark/src/mark/em.ts
@@ -1,6 +1,5 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import { createCmd, createCmdKey } from '@milkdown/core';
-import { markRule } from '@milkdown/prose';
 import { toggleMark } from '@milkdown/prose/commands';
 import { createMark, createShortcut } from '@milkdown/utils';
 
@@ -11,10 +10,10 @@ type Keys = SupportedKeys['Em'];
 const id = 'em';
 
 export const ToggleItalic = createCmdKey('ToggleItalic');
-
 export const em = createMark<Keys>((utils) => ({
     id,
     schema: () => ({
+        inclusive: false,
         parseDOM: [
             { tag: 'i' },
             { tag: 'em' },
@@ -36,10 +35,6 @@ export const em = createMark<Keys>((utils) => ({
             },
         },
     }),
-    inputRules: (markType) => [
-        // markRule(/(?:^|[^_])(_([^_]+)_)$/, markType),
-        // markRule(/(?:^|[^*])(\*([^*]+)\*)$/, markType),
-    ],
     commands: (markType) => [createCmd(ToggleItalic, () => toggleMark(markType))],
     shortcuts: {
         [SupportedKeys.Em]: createShortcut(ToggleItalic, 'Mod-i'),

--- a/packages/preset-commonmark/src/mark/link.ts
+++ b/packages/preset-commonmark/src/mark/link.ts
@@ -1,9 +1,8 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { commandsCtx, createCmd, createCmdKey, schemaCtx, ThemeInputChipType } from '@milkdown/core';
+import { commandsCtx, createCmd, createCmdKey, ThemeInputChipType } from '@milkdown/core';
 import { expectDomTypeError, missingRootElement } from '@milkdown/exception';
 import { calculateTextPosition } from '@milkdown/prose';
 import { toggleMark } from '@milkdown/prose/commands';
-import { InputRule } from '@milkdown/prose/inputrules';
 import { Node as ProseNode } from '@milkdown/prose/model';
 import { NodeSelection, Plugin, PluginKey, TextSelection } from '@milkdown/prose/state';
 import { EditorView } from '@milkdown/prose/view';
@@ -24,11 +23,11 @@ export const link = createMark<string, LinkOptions>((utils, options) => {
     return {
         id,
         schema: () => ({
+            inclusive: false,
             attrs: {
                 href: {},
                 title: { default: null },
             },
-            inclusive: false,
             parseDOM: [
                 {
                     tag: 'a[href]',
@@ -99,22 +98,6 @@ export const link = createMark<string, LinkOptions>((utils, options) => {
                 );
 
                 return true;
-            }),
-        ],
-        inputRules: (markType, ctx) => [
-            new InputRule(/\[(?<text>.*?)]\((?<href>.*?)(?=“|\))"?(?<title>[^"]+)?"?\)/, (state, match, start, end) => {
-                const [okay, text = '', href, title] = match;
-                const { tr } = state;
-                if (okay) {
-                    const content = text || 'link';
-                    tr.replaceWith(start, end, ctx.get(schemaCtx).text(content)).addMark(
-                        start,
-                        content.length + start,
-                        markType.create({ title, href }),
-                    );
-                }
-
-                return tr;
             }),
         ],
         prosePlugins: (type, ctx) => {

--- a/packages/preset-commonmark/src/mark/strong.ts
+++ b/packages/preset-commonmark/src/mark/strong.ts
@@ -1,6 +1,5 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import { createCmd, createCmdKey } from '@milkdown/core';
-import { markRule } from '@milkdown/prose';
 import { toggleMark } from '@milkdown/prose/commands';
 import { createMark, createShortcut } from '@milkdown/utils';
 
@@ -13,6 +12,7 @@ export const strong = createMark<Keys>((utils) => {
     return {
         id,
         schema: () => ({
+            inclusive: false,
             parseDOM: [
                 { tag: 'b' },
                 { tag: 'strong' },
@@ -34,10 +34,6 @@ export const strong = createMark<Keys>((utils) => {
                 },
             },
         }),
-        inputRules: (markType) => [
-            markRule(/(?:__)([^_]+)(?:__)$/, markType),
-            markRule(/(?:\*\*)([^*]+)(?:\*\*)$/, markType),
-        ],
         commands: (markType) => [createCmd(ToggleBold, () => toggleMark(markType))],
         shortcuts: {
             [SupportedKeys.Bold]: createShortcut(ToggleBold, 'Mod-b'),

--- a/packages/preset-commonmark/src/node/paragraph.ts
+++ b/packages/preset-commonmark/src/node/paragraph.ts
@@ -1,10 +1,52 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { createCmd, createCmdKey } from '@milkdown/core';
+import { createCmd, createCmdKey, Ctx, parserCtx, serializerCtx } from '@milkdown/core';
 import { setBlockType } from '@milkdown/prose/commands';
 import { Fragment, Node } from '@milkdown/prose/model';
+import { Plugin, PluginKey, TextSelection } from '@milkdown/prose/state';
 import { createNode, createShortcut } from '@milkdown/utils';
 
 import { SupportedKeys } from '../supported-keys';
+
+export const inlineMarkSyncPluginKey = new PluginKey('MARK_INLINE_MARK_SYNC_PLUGIN_KEY');
+export const inlineMarkSyncPlugin = (ctx: Ctx) => {
+    ctx;
+    return new Plugin({
+        key: inlineMarkSyncPluginKey,
+        appendTransaction(transactions, _oldState, newState) {
+            if (!transactions.some((tr) => tr.docChanged)) return null;
+            if (!newState.tr.isGeneric) return null;
+
+            const { selection } = newState;
+            const { $from } = selection;
+            const node = $from.node();
+            const isInlineBlock = node.type.spec.content?.includes('inline');
+            if (!isInlineBlock) return null;
+
+            const doc = newState.schema.topNodeType.createAndFill(undefined, node);
+            if (!doc) return null;
+
+            const parser = ctx.get(parserCtx);
+            const serializer = ctx.get(serializerCtx);
+            const text = serializer(doc).slice(0, -1).replaceAll('\\', '');
+            console.log(text);
+
+            const parsed = parser(text);
+
+            if (!parsed) return null;
+            console.log(parsed.firstChild);
+            console.log(parsed.firstChild?.textContent);
+            if (node.textContent === parsed.firstChild?.textContent) return null;
+
+            const from = $from.before();
+            const to = $from.after();
+            console.log(JSON.stringify(text));
+            console.log(from, to);
+            let tr = newState.tr.setMeta('addToHistory', false).replaceWith(from, to, parsed.content);
+            tr = tr.setSelection(TextSelection.near(tr.doc.resolve($from.pos)));
+            return tr;
+        },
+    });
+};
 
 type Keys = SupportedKeys['Text'];
 
@@ -56,5 +98,6 @@ export const paragraph = createNode<Keys>((utils) => {
         shortcuts: {
             [SupportedKeys.Text]: createShortcut(TurnIntoText, 'Mod-Alt-0'),
         },
+        prosePlugins: (_, ctx) => [inlineMarkSyncPlugin(ctx)],
     };
 });

--- a/packages/preset-commonmark/src/node/paragraph.ts
+++ b/packages/preset-commonmark/src/node/paragraph.ts
@@ -1,52 +1,10 @@
 /* Copyright 2021, Milkdown by Mirone. */
-import { createCmd, createCmdKey, Ctx, parserCtx, serializerCtx } from '@milkdown/core';
+import { createCmd, createCmdKey } from '@milkdown/core';
 import { setBlockType } from '@milkdown/prose/commands';
 import { Fragment, Node } from '@milkdown/prose/model';
-import { Plugin, PluginKey, TextSelection } from '@milkdown/prose/state';
 import { createNode, createShortcut } from '@milkdown/utils';
 
 import { SupportedKeys } from '../supported-keys';
-
-export const inlineMarkSyncPluginKey = new PluginKey('MARK_INLINE_MARK_SYNC_PLUGIN_KEY');
-export const inlineMarkSyncPlugin = (ctx: Ctx) => {
-    ctx;
-    return new Plugin({
-        key: inlineMarkSyncPluginKey,
-        appendTransaction(transactions, _oldState, newState) {
-            if (!transactions.some((tr) => tr.docChanged)) return null;
-            if (!newState.tr.isGeneric) return null;
-
-            const { selection } = newState;
-            const { $from } = selection;
-            const node = $from.node();
-            const isInlineBlock = node.type.spec.content?.includes('inline');
-            if (!isInlineBlock) return null;
-
-            const doc = newState.schema.topNodeType.createAndFill(undefined, node);
-            if (!doc) return null;
-
-            const parser = ctx.get(parserCtx);
-            const serializer = ctx.get(serializerCtx);
-            const text = serializer(doc).slice(0, -1).replaceAll('\\', '');
-            console.log(text);
-
-            const parsed = parser(text);
-
-            if (!parsed) return null;
-            console.log(parsed.firstChild);
-            console.log(parsed.firstChild?.textContent);
-            if (node.textContent === parsed.firstChild?.textContent) return null;
-
-            const from = $from.before();
-            const to = $from.after();
-            console.log(JSON.stringify(text));
-            console.log(from, to);
-            let tr = newState.tr.setMeta('addToHistory', false).replaceWith(from, to, parsed.content);
-            tr = tr.setSelection(TextSelection.near(tr.doc.resolve($from.pos)));
-            return tr;
-        },
-    });
-};
 
 type Keys = SupportedKeys['Text'];
 
@@ -98,6 +56,5 @@ export const paragraph = createNode<Keys>((utils) => {
         shortcuts: {
             [SupportedKeys.Text]: createShortcut(TurnIntoText, 'Mod-Alt-0'),
         },
-        prosePlugins: (_, ctx) => [inlineMarkSyncPlugin(ctx)],
     };
 });

--- a/packages/preset-commonmark/src/plugin/index.ts
+++ b/packages/preset-commonmark/src/plugin/index.ts
@@ -5,10 +5,11 @@ import links from 'remark-inline-links';
 import { addOrderInList } from './add-order-in-list';
 import { filterHTMLPlugin } from './filter-html';
 import { getInlineNodesCursorPlugin } from './inline-nodes-cursor';
+import { getInlineSyncPlugin } from './inline-sync';
 
 export const commonmarkPlugins = [
     createPlugin(() => ({
-        prosePlugins: () => [getInlineNodesCursorPlugin()],
+        prosePlugins: (_, ctx) => [getInlineNodesCursorPlugin(), getInlineSyncPlugin(ctx)],
         remarkPlugins: () => [links, filterHTMLPlugin, addOrderInList],
     }))(),
 ];

--- a/packages/preset-commonmark/src/plugin/inline-sync.ts
+++ b/packages/preset-commonmark/src/plugin/inline-sync.ts
@@ -1,0 +1,116 @@
+/* Copyright 2021, Milkdown by Mirone. */
+import { Ctx, editorViewCtx, parserCtx, serializerCtx } from '@milkdown/core';
+import { Node } from '@milkdown/prose/model';
+import { Plugin, PluginKey, TextSelection } from '@milkdown/prose/state';
+
+type InlineSyncPluginState = {
+    isInlineBlock: boolean;
+    originalNode: Node | null;
+    targetNode: Node | null;
+};
+type InlineSyncPlugin = Plugin<InlineSyncPluginState>;
+
+export const inlineSyncPluginKey = new PluginKey('MILKDOWN_INLINE_SYNC');
+export const getInlineSyncPlugin = (ctx: Ctx) => {
+    const inlineSyncPlugin: InlineSyncPlugin = new Plugin<InlineSyncPluginState>({
+        key: inlineSyncPluginKey,
+        state: {
+            init: () => {
+                return {
+                    isInlineBlock: false,
+                    originalNode: null,
+                    targetNode: null,
+                };
+            },
+            apply: (_tr, _value, _oldState, state) => {
+                const { selection } = state;
+                const { $from } = selection;
+
+                const node = $from.node();
+                const doc = state.schema.topNodeType.create(undefined, node);
+                const isInlineBlock = Boolean(node.type.spec.content?.includes('inline'));
+
+                const parser = ctx.get(parserCtx);
+                const serializer = ctx.get(serializerCtx);
+                const text = serializer(doc).slice(0, -1).replaceAll('\\', '');
+                const parsed = parser(text);
+                if (!parsed)
+                    return {
+                        isInlineBlock: false,
+                        originalNode: null,
+                        targetNode: null,
+                    };
+
+                const target = parsed.firstChild;
+
+                if (!target || node.type !== target.type)
+                    return {
+                        isInlineBlock: false,
+                        originalNode: null,
+                        targetNode: null,
+                    };
+
+                return {
+                    isInlineBlock,
+                    originalNode: node,
+                    targetNode: target,
+                };
+            },
+        },
+        props: {
+            handleTextInput: (view, _, to) => {
+                if (view.composing) return false;
+                const pluginState = inlineSyncPlugin.getState(view.state);
+                if (pluginState?.isInlineBlock) {
+                    view.dispatch(view.state.tr.setMeta(inlineSyncPluginKey, true).insertText('\uFFFC', to));
+                }
+                return false;
+            },
+        },
+        appendTransaction(transactions) {
+            if (!transactions.some((tr) => tr.docChanged)) return null;
+            if (!transactions.some((tr) => tr.getMeta(inlineSyncPluginKey))) return null;
+
+            requestAnimationFrame(() => {
+                const { state, dispatch } = ctx.get(editorViewCtx);
+
+                const { selection } = state;
+                const { $from } = selection;
+
+                const pluginState = inlineSyncPlugin.getState(state);
+                if (!pluginState) return;
+
+                const { targetNode, originalNode } = pluginState;
+                if (!targetNode || !originalNode) return;
+
+                const from = $from.before();
+                const to = $from.after();
+
+                const tr = state.tr.setMeta('addToHistory', false).replaceWith(from, to, targetNode);
+
+                let offset = from;
+                let find = false;
+                targetNode.descendants((n) => {
+                    if (find) return false;
+                    if (n.isText) {
+                        const i = n.text?.indexOf('\uFFFC');
+                        if (i != null && i >= 0) {
+                            find = true;
+                            offset += i;
+                            return false;
+                        }
+                    }
+                    offset += n.nodeSize;
+                    return;
+                });
+
+                tr.delete(offset + 1, offset + 2);
+                tr.setSelection(TextSelection.near(tr.doc.resolve(offset + 1)));
+                dispatch(tr);
+            });
+            return null;
+        },
+    });
+
+    return inlineSyncPlugin;
+};

--- a/packages/preset-commonmark/src/plugin/inline-sync.ts
+++ b/packages/preset-commonmark/src/plugin/inline-sync.ts
@@ -4,6 +4,7 @@ import { Attrs, Node } from '@milkdown/prose/model';
 import { EditorState, Plugin, PluginKey, TextSelection, Transaction } from '@milkdown/prose/state';
 
 const placeholder = '⁂';
+// const placeholder = '\u2234';
 const regexp = new RegExp(`\\\\(?=[^\\w\\s${placeholder}\\\\]|_)`, 'g');
 
 const swap = (text: string, first: number, last: number) => {
@@ -20,7 +21,7 @@ const movePlaceholder = (text: string) => {
     const symbolsNeedToMove = ['*', '_'];
 
     let index = text.indexOf(placeholder);
-    while (symbolsNeedToMove.includes(text[index + 1] || '')) {
+    while (symbolsNeedToMove.includes(text[index - 1] || '') && symbolsNeedToMove.includes(text[index + 1] || '')) {
         text = swap(text, index, index + 1);
         index = index + 1;
     }

--- a/packages/preset-commonmark/src/plugin/inline-sync.ts
+++ b/packages/preset-commonmark/src/plugin/inline-sync.ts
@@ -11,6 +11,7 @@ type InlineSyncPluginState = {
 type InlineSyncPlugin = Plugin<InlineSyncPluginState>;
 
 const placeholder = '⁂';
+const regexp = new RegExp(`\\\\(?=[^\\w\\s${placeholder}\\\\]|_)`, 'g');
 
 export const inlineSyncPluginKey = new PluginKey('MILKDOWN_INLINE_SYNC');
 export const getInlineSyncPlugin = (ctx: Ctx) => {
@@ -53,7 +54,7 @@ export const getInlineSyncPlugin = (ctx: Ctx) => {
 
                 const parser = ctx.get(parserCtx);
                 const serializer = ctx.get(serializerCtx);
-                const text = serializer(doc).slice(0, -1).replaceAll('\\', '');
+                const text = serializer(doc).slice(0, -1).replaceAll(regexp, '');
                 const parsed = parser(text);
                 if (!parsed)
                     return {

--- a/packages/preset-commonmark/src/plugin/inline-sync.ts
+++ b/packages/preset-commonmark/src/plugin/inline-sync.ts
@@ -1,15 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import { Ctx, editorViewCtx, parserCtx, serializerCtx } from '@milkdown/core';
-import { Node } from '@milkdown/prose/model';
-import { Plugin, PluginKey, TextSelection } from '@milkdown/prose/state';
-
-type InlineSyncPluginState = {
-    text: string;
-    isInlineBlock: boolean;
-    originalNode: Node | null;
-    targetNode: Node | null;
-};
-type InlineSyncPlugin = Plugin<InlineSyncPluginState>;
+import { Attrs, Node } from '@milkdown/prose/model';
+import { EditorState, Plugin, PluginKey, TextSelection, Transaction } from '@milkdown/prose/state';
 
 const placeholder = '⁂';
 const regexp = new RegExp(`\\\\(?=[^\\w\\s${placeholder}\\\\]|_)`, 'g');
@@ -28,7 +20,7 @@ const movePlaceholder = (text: string) => {
     const symbolsNeedToMove = ['*', '_'];
 
     let index = text.indexOf(placeholder);
-    while (symbolsNeedToMove.includes(text[index - 1] || '') && symbolsNeedToMove.includes(text[index + 1] || '')) {
+    while (symbolsNeedToMove.includes(text[index + 1] || '')) {
         text = swap(text, index, index + 1);
         index = index + 1;
     }
@@ -36,130 +28,144 @@ const movePlaceholder = (text: string) => {
     return text;
 };
 
+const getOffset = (node: Node, from: number) => {
+    let offset = from;
+    let find = false;
+    node.descendants((n) => {
+        if (find) return false;
+        if (n.isText) {
+            const i = n.text?.indexOf(placeholder);
+            if (i != null && i >= 0) {
+                find = true;
+                offset += i;
+                return false;
+            }
+        }
+        offset += n.nodeSize;
+        return;
+    });
+    return offset;
+};
+
 export const inlineSyncPluginKey = new PluginKey('MILKDOWN_INLINE_SYNC');
 export const getInlineSyncPlugin = (ctx: Ctx) => {
-    const getOffset = (node: Node, from: number) => {
-        let offset = from;
-        let find = false;
-        node.descendants((n) => {
-            if (find) return false;
-            if (n.isText) {
-                const i = n.text?.indexOf(placeholder);
-                if (i != null && i >= 0) {
-                    find = true;
-                    offset += i;
-                    return false;
-                }
-            }
-            offset += n.nodeSize;
-            return;
-        });
-        return offset;
+    const getContextByState = (state: EditorState) => {
+        const { selection } = state;
+        const { $from } = selection;
+
+        const node = $from.node();
+        const doc = state.schema.topNodeType.create(undefined, node);
+        const isInlineBlock = Boolean(node.type.spec.content?.includes('inline'));
+
+        const parser = ctx.get(parserCtx);
+        const serializer = ctx.get(serializerCtx);
+        const text = serializer(doc).slice(0, -1).replaceAll(regexp, '');
+        const parsed = parser(movePlaceholder(text));
+        if (!parsed) return null;
+
+        const target = parsed.firstChild;
+
+        if (!target || node.type !== target.type) return null;
+
+        return {
+            text,
+            isInlineBlock,
+            prevNode: node,
+            nextNode: target,
+        };
     };
 
-    const getInitialState = (): InlineSyncPluginState => ({
-        isInlineBlock: false,
-        originalNode: null,
-        targetNode: null,
-        text: '',
-    });
+    const runReplacer = (
+        prevState: EditorState,
+        state: EditorState,
+        dispatch: (tr: Transaction) => void,
+        attrs: Attrs,
+    ) => {
+        const { selection } = state;
+        const { $from } = selection;
+        const from = $from.before();
+        const to = $from.after();
 
-    const inlineSyncPlugin: InlineSyncPlugin = new Plugin<InlineSyncPluginState>({
+        let tr = state.tr.setMeta(inlineSyncPluginKey, true).insertText(placeholder, selection.from);
+        const cleanUpOnFail = () => {
+            const offset = getOffset($from.node(), from);
+            dispatch(tr.delete(offset + 1, offset + 2));
+        };
+
+        // If doc structure is changed, remove the placeholder.
+        if (prevState.doc.resolve(from).node().type !== state.doc.resolve(from).node().type) {
+            let offset = 0;
+            let find = false;
+            state.doc.descendants((n, pos) => {
+                if (find) return false;
+                if (n.isText && n.text === placeholder) {
+                    find = true;
+                    offset = pos;
+                }
+                return;
+            });
+            if (!find) return;
+
+            dispatch(tr.delete(offset, offset + 1));
+
+            return;
+        }
+
+        const context = getContextByState(state.apply(tr));
+
+        if (!context) {
+            cleanUpOnFail();
+            return;
+        }
+
+        const offset = getOffset(context.nextNode, from);
+
+        tr = tr.replaceWith(from, to, context.nextNode);
+        tr = tr.setNodeMarkup(from, undefined, attrs);
+        tr = tr.delete(offset + 1, offset + 2);
+        tr = tr.setSelection(TextSelection.near(tr.doc.resolve(offset + 1)));
+        dispatch(tr);
+    };
+
+    const inlineSyncPlugin = new Plugin<null>({
         key: inlineSyncPluginKey,
         state: {
             init: () => {
-                return getInitialState();
+                return null;
             },
-            apply: (_tr, _value, _oldState, state) => {
-                const { selection } = state;
+            apply: (tr, _value, _oldState, newState) => {
+                if (!tr.docChanged) return null;
+
+                const meta = tr.getMeta(inlineSyncPluginKey);
+                if (meta) return null;
+
+                const { selection } = tr;
                 const { $from } = selection;
 
-                const node = $from.node();
-                const doc = state.schema.topNodeType.create(undefined, node);
-                const isInlineBlock = Boolean(node.type.spec.content?.includes('inline'));
+                const prevNode = $from.node();
+                const doc = newState.schema.topNodeType.create(undefined, prevNode);
+                const isInlineBlock = Boolean(prevNode.type.spec.content?.includes('inline'));
+                if (!isInlineBlock) return null;
 
                 const parser = ctx.get(parserCtx);
                 const serializer = ctx.get(serializerCtx);
                 const text = serializer(doc).slice(0, -1).replaceAll(regexp, '');
                 const parsed = parser(movePlaceholder(text));
-                if (!parsed) return getInitialState();
 
-                const target = parsed.firstChild;
+                if (!parsed) return null;
 
-                if (!target || node.type !== target.type) return getInitialState();
+                const nextNode = parsed.firstChild;
 
-                return {
-                    text,
-                    isInlineBlock,
-                    originalNode: node,
-                    targetNode: target,
-                };
+                if (!nextNode || prevNode.type !== nextNode.type) return null;
+
+                requestAnimationFrame(() => {
+                    const { dispatch, state } = ctx.get(editorViewCtx);
+
+                    runReplacer(newState, state, dispatch, prevNode.attrs);
+                });
+
+                return null;
             },
-        },
-        props: {
-            handleTextInput: (view, _, to) => {
-                if (view.composing) return false;
-                const pluginState = inlineSyncPlugin.getState(view.state);
-                if (pluginState?.isInlineBlock) {
-                    view.dispatch(view.state.tr.setMeta(inlineSyncPluginKey, true).insertText(placeholder, to));
-                }
-                return false;
-            },
-        },
-        appendTransaction(transactions, _oldState, newState) {
-            const triggerTr = transactions.find((tr) => tr.getMeta(inlineSyncPluginKey));
-            if (!triggerTr) return null;
-
-            requestAnimationFrame(() => {
-                const { state, dispatch } = ctx.get(editorViewCtx);
-
-                const { selection } = state;
-                const { $from } = selection;
-                const from = $from.before();
-                const to = $from.after();
-
-                const cleanUpOnFail = () => {
-                    const offset = getOffset($from.node(), from);
-                    dispatch(state.tr.delete(offset + 1, offset + 2));
-                };
-
-                // If doc structure is changed, remove the placeholder.
-                if (newState.doc.resolve(from).node().type !== state.doc.resolve(from).node().type) {
-                    let offset = 0;
-                    let find = false;
-                    state.doc.descendants((n, pos) => {
-                        if (find) return false;
-                        if (n.isText && n.text === placeholder) {
-                            find = true;
-                            offset = pos;
-                        }
-                        return;
-                    });
-                    dispatch(state.tr.delete(offset, offset + 1));
-
-                    return;
-                }
-
-                const pluginState = inlineSyncPlugin.getState(state);
-                if (!pluginState) {
-                    cleanUpOnFail();
-                    return;
-                }
-
-                const { targetNode, originalNode } = pluginState;
-                if (!targetNode || !originalNode) {
-                    cleanUpOnFail();
-                    return;
-                }
-
-                const offset = getOffset(targetNode, from);
-
-                let tr = state.tr.replaceWith(from, to, targetNode);
-                tr = tr.delete(offset + 1, offset + 2);
-                tr = tr.setSelection(TextSelection.near(tr.doc.resolve(offset + 1)));
-                dispatch(tr);
-            });
-            return null;
         },
     });
 

--- a/packages/preset-commonmark/src/plugin/inline-sync.ts
+++ b/packages/preset-commonmark/src/plugin/inline-sync.ts
@@ -140,23 +140,12 @@ export const getInlineSyncPlugin = (ctx: Ctx) => {
                 const meta = tr.getMeta(inlineSyncPluginKey);
                 if (meta) return null;
 
-                const { selection } = tr;
-                const { $from } = selection;
+                const context = getContextByState(newState);
+                if (!context) return null;
 
-                const prevNode = $from.node();
-                const doc = newState.schema.topNodeType.create(undefined, prevNode);
-                const isInlineBlock = Boolean(prevNode.type.spec.content?.includes('inline'));
+                const { isInlineBlock, prevNode, nextNode } = context;
+
                 if (!isInlineBlock) return null;
-
-                const parser = ctx.get(parserCtx);
-                const serializer = ctx.get(serializerCtx);
-                const text = serializer(doc).slice(0, -1).replaceAll(regexp, '');
-                const parsed = parser(movePlaceholder(text));
-
-                if (!parsed) return null;
-
-                const nextNode = parsed.firstChild;
-
                 if (!nextNode || prevNode.type !== nextNode.type) return null;
 
                 requestAnimationFrame(() => {

--- a/packages/preset-commonmark/src/plugin/inline-sync.ts
+++ b/packages/preset-commonmark/src/plugin/inline-sync.ts
@@ -2,6 +2,7 @@
 import { Ctx, editorViewCtx, parserCtx, serializerCtx } from '@milkdown/core';
 import { Attrs, Node } from '@milkdown/prose/model';
 import { EditorState, Plugin, PluginKey, TextSelection, Transaction } from '@milkdown/prose/state';
+import { pipe } from '@milkdown/utils';
 
 const holePlaceholder = '∅';
 
@@ -33,6 +34,10 @@ const movePlaceholder = (text: string) => {
 
     return text;
 };
+
+const removeLf = (text: string) => text.slice(0, -1);
+const replacePunctuation = (text: string) => text.replace(regexp, '');
+const handleText = pipe(removeLf, replacePunctuation, movePlaceholder);
 
 const calculatePlaceholder = (text: string) => {
     const index = text.indexOf(holePlaceholder);
@@ -89,7 +94,9 @@ export const getInlineSyncPlugin = (ctx: Ctx) => {
         const parser = ctx.get(parserCtx);
         const serializer = ctx.get(serializerCtx);
 
-        const text = movePlaceholder(serializer(doc).slice(0, -1).replaceAll(regexp, ''));
+        const markdown = serializer(doc);
+
+        const text = handleText(markdown);
         const placeholder = calculatePlaceholder(text);
 
         const parsed = parser(text.replace(holePlaceholder, placeholder));

--- a/packages/preset-gfm/src/strike-through.ts
+++ b/packages/preset-gfm/src/strike-through.ts
@@ -1,6 +1,5 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import { createCmd, createCmdKey } from '@milkdown/core';
-import { markRule } from '@milkdown/prose';
 import { toggleMark } from '@milkdown/prose/commands';
 import { createMark, createShortcut } from '@milkdown/utils';
 
@@ -35,10 +34,6 @@ export const strikeThrough = createMark<Keys>((utils) => {
                 },
             },
         }),
-        inputRules: (markType) => [
-            markRule(/(?:~~)([^~]+)(?:~~)$/, markType),
-            markRule(/(?:^|[^~])(~([^~]+)~)$/, markType),
-        ],
         commands: (markType) => [createCmd(ToggleStrikeThrough, () => toggleMark(markType))],
         shortcuts: {
             [SupportedKeys.StrikeThrough]: createShortcut(ToggleStrikeThrough, 'Mod-Alt-x'),

--- a/packages/preset-gfm/src/strike-through.ts
+++ b/packages/preset-gfm/src/strike-through.ts
@@ -14,6 +14,7 @@ export const strikeThrough = createMark<Keys>((utils) => {
     return {
         id,
         schema: () => ({
+            inclusive: false,
             parseDOM: [
                 { tag: 'del' },
                 { style: 'text-decoration', getAttrs: (value) => (value === 'line-through') as false },

--- a/packages/transformer/src/parser/index.ts
+++ b/packages/transformer/src/parser/index.ts
@@ -6,12 +6,12 @@ import { createStack } from './stack';
 import { State } from './state';
 import type { InnerParserSpecMap } from './types';
 
-export const createParser =
-    (schema: Schema, specMap: InnerParserSpecMap, remark: RemarkParser) =>
-    (text: string): Node => {
-        const state = new State(createStack(schema), schema, specMap);
+export const createParser = (schema: Schema, specMap: InnerParserSpecMap, remark: RemarkParser) => {
+    const state = new State(createStack(schema), schema, specMap);
+    return (text: string): Node => {
         state.run(remark, text);
         return state.toDoc();
     };
+};
 
 export * from './types';

--- a/packages/transformer/src/parser/state.ts
+++ b/packages/transformer/src/parser/state.ts
@@ -45,7 +45,7 @@ export class State {
      * @returns The state instance.
      */
     run = (remark: RemarkParser, markdown: string) => {
-        const tree = remark.runSync(remark.parse(markdown)) as MarkdownNode;
+        const tree = remark.runSync(remark.parse(markdown), markdown) as MarkdownNode;
         this.next(tree);
 
         return this;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -3,4 +3,5 @@ export * from './atom';
 export * from './composable';
 export * from './factory';
 export * from './macro';
+export * from './pipe';
 export * from './types';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "target": "es2015",
         "module": "esnext",
-        "lib": ["dom", "es2017", "es2018", "es2019"],
+        "lib": ["dom", "es2017", "es2018", "es2019", "es2020", "es2021"],
         "noEmitOnError": true,
 
         "declaration": true,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

There're lots of bugs caused by consistency between markdown AST and UI.

For example:
https://github.com/Saul-Mirone/milkdown/issues/637
https://github.com/Saul-Mirone/milkdown/issues/553
https://github.com/Saul-Mirone/milkdown/issues/622

The `inline-sync-plugin` can help to solve this issue. Instead of using inputrules to check user input, this plugin keep sync the prosemirror node between markdown AST for inline nodes (such as `paragraph` and `heading`).

## How did you test this change?

Manually test and e2e test.
