### PR TITLE
fix: 🐛 inline sync plugin debounce and disable at readonly

### DIFF
--- a/packages/preset-commonmark/src/plugin/inline-sync/index.ts
+++ b/packages/preset-commonmark/src/plugin/inline-sync/index.ts
@@ -10,6 +10,7 @@ export * from './config';
 
 export const inlineSyncPluginKey = new PluginKey('MILKDOWN_INLINE_SYNC');
 export const getInlineSyncPlugin = (ctx: Ctx) => {
+    let requestId: number | null = null;
     const inlineSyncPlugin = new Plugin<null>({
         key: inlineSyncPluginKey,
         state: {
@@ -17,6 +18,14 @@ export const getInlineSyncPlugin = (ctx: Ctx) => {
                 return null;
             },
             apply: (tr, _value, _oldState, newState) => {
+                const view = ctx.get(editorViewCtx);
+                if (!view.hasFocus?.() || !view.editable) return null;
+
+                if (requestId) {
+                    cancelAnimationFrame(requestId);
+                    requestId = null;
+                }
+
                 if (!tr.docChanged) return null;
 
                 const meta = tr.getMeta(inlineSyncPluginKey);
@@ -33,7 +42,9 @@ export const getInlineSyncPlugin = (ctx: Ctx) => {
 
                 if (!shouldSyncNode({ prevNode, nextNode, ctx, tr, text })) return null;
 
-                requestAnimationFrame(() => {
+                requestId = requestAnimationFrame(() => {
+                    requestId = null;
+
                     const { dispatch, state } = ctx.get(editorViewCtx);
 
                     runReplacer(ctx, inlineSyncPluginKey, state, dispatch, prevNode.attrs);

--- a/packages/preset-commonmark/src/plugin/inline-sync/index.ts
+++ b/packages/preset-commonmark/src/plugin/inline-sync/index.ts
@@ -21,11 +21,6 @@ export const getInlineSyncPlugin = (ctx: Ctx) => {
                 const view = ctx.get(editorViewCtx);
                 if (!view.hasFocus?.() || !view.editable) return null;
 
-                if (requestId) {
-                    cancelAnimationFrame(requestId);
-                    requestId = null;
-                }
-
                 if (!tr.docChanged) return null;
 
                 const meta = tr.getMeta(inlineSyncPluginKey);
@@ -35,6 +30,11 @@ export const getInlineSyncPlugin = (ctx: Ctx) => {
 
                 const context = getContextByState(ctx, newState);
                 if (!context) return null;
+
+                if (requestId) {
+                    cancelAnimationFrame(requestId);
+                    requestId = null;
+                }
 
                 const { prevNode, nextNode, text } = context;
 


### PR DESCRIPTION
## Summary
1. If active inline sync plugin at readonly, it causes heading flash after clicked.
2. If no debounce, it cause infinite loop of inline sync update. (by performance tool)

Both of above cause by inputing content like
```md
1. a

# [b]()
```
I think multiple plugins break each other.

But i am not sure whether debounce will cause state lost or not, please check it.

## How did you test this change?
Run an example.
