### PR TITLE
[RFC]: make plugins can be removed

### DIFF
--- a/packages/core/src/editor/editor.ts
+++ b/packages/core/src/editor/editor.ts
@@ -71,13 +71,14 @@ export class Editor {
 
     /**
      * Get the ctx of the editor.
-     *
-     * @returns The ctx of the editor.
      */
     get ctx() {
         return this.#ctx;
     }
 
+    /**
+     * Get the status of the editor.
+     */
     get status() {
         return this.#status;
     }
@@ -169,6 +170,11 @@ export class Editor {
         return this;
     };
 
+    /**
+     * Destroy the editor.
+     *
+     * @returns A promise object, will be resolved as editor instance after destroy finish.
+     */
     readonly destroy = async () => {
         await Promise.all(
             [...this.#plugins.entries()].map(async ([key, loader]) => {

--- a/packages/core/src/editor/editor.ts
+++ b/packages/core/src/editor/editor.ts
@@ -62,6 +62,13 @@ export class Editor {
         this.use(internalPlugins.concat(configPlugin));
     };
 
+    readonly #prepare = () => {
+        [...this.#plugins.entries()].map(async ([key, loader]) => {
+            const handler = loader.handler ?? key(this.#pre);
+            this.#plugins.set(key, { ...loader, handler });
+        });
+    };
+
     /**
      * Get the ctx of the editor.
      *
@@ -123,10 +130,7 @@ export class Editor {
     readonly create = async () => {
         this.#loadInternal();
 
-        [...this.#plugins.entries()].map(async ([key, loader]) => {
-            const handler = loader.handler ?? key(this.#pre);
-            this.#plugins.set(key, { ...loader, handler });
-        });
+        this.#prepare();
 
         await Promise.all(
             [...this.#plugins.entries()].map(async ([key, loader]) => {

--- a/packages/core/src/internal-plugin/commands.ts
+++ b/packages/core/src/internal-plugin/commands.ts
@@ -77,5 +77,9 @@ export const commands: MilkdownPlugin = (pre) => {
         ctx.done(CommandsReady);
         await ctx.wait(EditorViewReady);
         commandManager.setCtx(ctx);
+
+        return (post) => {
+            post.remove(commandsCtx).remove(commandsTimerCtx).clearTimer(CommandsReady);
+        };
     };
 };

--- a/packages/core/src/internal-plugin/config.ts
+++ b/packages/core/src/internal-plugin/config.ts
@@ -11,5 +11,9 @@ export const config =
         return async (ctx) => {
             await configure(ctx);
             ctx.done(ConfigReady);
+
+            return (post) => {
+                post.clearTimer(ConfigReady);
+            };
         };
     };

--- a/packages/core/src/internal-plugin/editor-state.ts
+++ b/packages/core/src/internal-plugin/editor-state.ts
@@ -89,5 +89,13 @@ export const editorState: MilkdownPlugin = (pre) => {
         const state = EditorState.create(options);
         ctx.set(editorStateCtx, state);
         ctx.done(EditorStateReady);
+
+        return (post) => {
+            post.remove(defaultValueCtx)
+                .remove(editorStateCtx)
+                .remove(editorStateOptionsCtx)
+                .remove(editorStateTimerCtx)
+                .clearTimer(EditorStateReady);
+        };
     };
 };

--- a/packages/core/src/internal-plugin/editor-view.ts
+++ b/packages/core/src/internal-plugin/editor-view.ts
@@ -92,6 +92,7 @@ export const editorView: MilkdownPlugin = (pre) => {
         ctx.done(EditorViewReady);
 
         return (post) => {
+            view?.destroy();
             post.remove(rootCtx)
                 .remove(editorViewCtx)
                 .remove(editorViewOptionsCtx)

--- a/packages/core/src/internal-plugin/editor-view.ts
+++ b/packages/core/src/internal-plugin/editor-view.ts
@@ -90,5 +90,14 @@ export const editorView: MilkdownPlugin = (pre) => {
         prepareViewDom(view.dom);
         ctx.set(editorViewCtx, view);
         ctx.done(EditorViewReady);
+
+        return (post) => {
+            post.remove(rootCtx)
+                .remove(editorViewCtx)
+                .remove(editorViewOptionsCtx)
+                .remove(rootDOMCtx)
+                .remove(editorViewTimerCtx)
+                .clearTimer(EditorViewReady);
+        };
     };
 };

--- a/packages/core/src/internal-plugin/init.ts
+++ b/packages/core/src/internal-plugin/init.ts
@@ -49,5 +49,18 @@ export const init =
             ctx.set(remarkCtx, unified().use(remarkParse).use(remarkStringify, options));
 
             ctx.done(InitReady);
+
+            return (post) => {
+                post.remove(editorCtx)
+                    .remove(prosePluginsCtx)
+                    .remove(remarkPluginsCtx)
+                    .remove(inputRulesCtx)
+                    .remove(nodeViewCtx)
+                    .remove(markViewCtx)
+                    .remove(remarkStringifyOptionsCtx)
+                    .remove(remarkCtx)
+                    .remove(initTimerCtx)
+                    .clearTimer(InitReady);
+            };
         };
     };

--- a/packages/core/src/internal-plugin/parser.ts
+++ b/packages/core/src/internal-plugin/parser.ts
@@ -34,5 +34,8 @@ export const parser: MilkdownPlugin = (pre) => {
 
         ctx.set(parserCtx, createParser(schema, spec, remark));
         ctx.done(ParserReady);
+        return (post) => {
+            post.remove(parserCtx).remove(parserTimerCtx).clearTimer(ParserReady);
+        };
     };
 };

--- a/packages/core/src/internal-plugin/schema.ts
+++ b/packages/core/src/internal-plugin/schema.ts
@@ -62,5 +62,9 @@ export const schema: MilkdownPlugin = (pre) => {
         );
 
         ctx.done(SchemaReady);
+
+        return (post) => {
+            post.remove(schemaCtx).remove(nodesCtx).remove(marksCtx).remove(schemaTimerCtx).clearTimer(SchemaReady);
+        };
     };
 };

--- a/packages/core/src/internal-plugin/serializer.ts
+++ b/packages/core/src/internal-plugin/serializer.ts
@@ -26,5 +26,9 @@ export const serializer: MilkdownPlugin = (pre) => {
 
         ctx.set(serializerCtx, createSerializer(schema, spec, remark));
         ctx.done(SerializerReady);
+
+        return (post) => {
+            post.remove(serializerCtx).remove(serializerTimerCtx).clearTimer(SerializerReady);
+        };
     };
 };

--- a/packages/core/src/internal-plugin/theme.ts
+++ b/packages/core/src/internal-plugin/theme.ts
@@ -62,6 +62,15 @@ export const themeEnvironment: MilkdownPlugin = (pre) => {
                 }),
             ),
         );
+
+        return (post) => {
+            post.remove(emotionConfigCtx)
+                .remove(emotionCtx)
+                .remove(themeManagerCtx)
+                .remove(themeTimerCtx)
+                .clearTimer(ThemeReady)
+                .clearTimer(ThemeEnvironmentReady);
+        };
     };
 };
 

--- a/packages/ctx/src/context/container.spec.ts
+++ b/packages/ctx/src/context/container.spec.ts
@@ -25,4 +25,18 @@ describe('context/container', () => {
 
         expect(container.getSlice<number>('num').get()).toBe(10);
     });
+
+    it('removeSlice', () => {
+        const container = createContainer();
+        const ctx = createSlice(0, 'num');
+
+        ctx(container.sliceMap);
+
+        expect(container.getSlice(ctx).id).toBe(ctx.id);
+        expect(container.getSlice(ctx).get()).toBe(0);
+
+        container.removeSlice(ctx);
+
+        expect(() => container.getSlice(ctx)).toThrow();
+    });
 });

--- a/packages/ctx/src/context/container.ts
+++ b/packages/ctx/src/context/container.ts
@@ -4,8 +4,9 @@ import { contextNotFound } from '@milkdown/exception';
 import { $Slice, Slice } from './slice';
 
 export type Container = {
-    readonly getSlice: <T, N extends string = string>(slice: Slice<T, N> | N) => $Slice<T, N>;
     readonly sliceMap: Map<symbol, $Slice>;
+    readonly getSlice: <T, N extends string = string>(slice: Slice<T, N> | N) => $Slice<T, N>;
+    readonly removeSlice: <T, N extends string = string>(slice: Slice<T, N> | N) => void;
 };
 
 export const createContainer = (): Container => {
@@ -22,5 +23,14 @@ export const createContainer = (): Container => {
         return context as $Slice<T, N>;
     };
 
-    return { getSlice, sliceMap };
+    const removeSlice = <T, N extends string = string>(slice: Slice<T, N> | N): void => {
+        const context =
+            typeof slice === 'string' ? [...sliceMap.values()].find((x) => x.name === slice) : sliceMap.get(slice.id);
+
+        if (!context) return;
+
+        sliceMap.delete(context.id);
+    };
+
+    return { sliceMap, getSlice, removeSlice };
 };

--- a/packages/ctx/src/context/slice.ts
+++ b/packages/ctx/src/context/slice.ts
@@ -21,7 +21,7 @@ export type Slice<T, N extends string = string> = {
 };
 
 export const createSlice = <T, N extends string = string>(value: T, name: N): Slice<T, N> => {
-    const id = Symbol('Context');
+    const id = Symbol(`Context-${name}`);
 
     const factory = (container: SliceMap, resetValue = shallowClone(value)) => {
         let inner = resetValue;

--- a/packages/ctx/src/plugin/ctx.ts
+++ b/packages/ctx/src/plugin/ctx.ts
@@ -24,17 +24,6 @@ export class Ctx {
         this.#container.getSlice(slice);
 
     /**
-     * Remove a context from current editor.
-     *
-     * @param ctx - The context needs to be removed.
-     * @returns Ctx.
-     */
-    readonly remove = <T, N extends string = string>(ctx: Slice<T, N> | N) => {
-        this.#container.removeSlice(ctx);
-        return this;
-    };
-
-    /**
      * Get the slice value.
      *
      * @param slice - The slice needs to be used.
@@ -73,17 +62,6 @@ export class Ctx {
      * @returns The timer instance.
      */
     readonly timing = (timer: Timer) => this.#clock.get(timer);
-
-    /**
-     * Clear a timer record.
-     *
-     * @param timer - The timer needs to be cleared.
-     * @returns Env.
-     */
-    readonly clearTimer = (timer: Timer) => {
-        this.#clock.remove(timer);
-        return this;
-    };
 
     /**
      * Wait for a timer to finish.

--- a/packages/ctx/src/plugin/ctx.ts
+++ b/packages/ctx/src/plugin/ctx.ts
@@ -24,6 +24,17 @@ export class Ctx {
         this.#container.getSlice(slice);
 
     /**
+     * Remove a context from current editor.
+     *
+     * @param ctx - The context needs to be removed.
+     * @returns Ctx.
+     */
+    readonly remove = <T, N extends string = string>(ctx: Slice<T, N> | N) => {
+        this.#container.removeSlice(ctx);
+        return this;
+    };
+
+    /**
      * Get the slice value.
      *
      * @param slice - The slice needs to be used.
@@ -62,6 +73,17 @@ export class Ctx {
      * @returns The timer instance.
      */
     readonly timing = (timer: Timer) => this.#clock.get(timer);
+
+    /**
+     * Clear a timer record.
+     *
+     * @param timer - The timer needs to be cleared.
+     * @returns Env.
+     */
+    readonly clearTimer = (timer: Timer) => {
+        this.#clock.remove(timer);
+        return this;
+    };
 
     /**
      * Wait for a timer to finish.

--- a/packages/ctx/src/plugin/ctx.ts
+++ b/packages/ctx/src/plugin/ctx.ts
@@ -64,20 +64,20 @@ export class Ctx {
     readonly timing = (timer: Timer) => this.#clock.get(timer);
 
     /**
-     * Wait for a timer to finish.
-     *
-     * @param timer - The timer needs to be used.
-     * @returns A promise that will be resolved when timer finish.
-     */
-    readonly wait = (timer: Timer) => this.timing(timer)();
-
-    /**
      * Finish a timer
      *
      * @param timer - The timer needs to be finished.
      * @returns
      */
     readonly done = (timer: Timer) => this.timing(timer).done();
+
+    /**
+     * Wait for a timer to finish.
+     *
+     * @param timer - The timer needs to be used.
+     * @returns A promise that will be resolved when timer finish.
+     */
+    readonly wait = (timer: Timer) => this.timing(timer)();
 
     /**
      * Wait for a list of timers in target slice to be all finished.

--- a/packages/ctx/src/plugin/env.ts
+++ b/packages/ctx/src/plugin/env.ts
@@ -16,7 +16,7 @@ export class Env {
      *
      * @param ctx - The context needs to be injected.
      * @param defaultValue - The default value of this context.
-     * @returns Pre.
+     * @returns Env.
      */
     readonly inject = <T>(ctx: Slice<T>, defaultValue?: T) => {
         ctx(this.#container.sliceMap, defaultValue);
@@ -24,13 +24,35 @@ export class Env {
     };
 
     /**
+     * Remove a context from current editor.
+     *
+     * @param ctx - The context needs to be removed.
+     * @returns Env.
+     */
+    readonly remove = <T, N extends string = string>(ctx: Slice<T, N> | N) => {
+        this.#container.removeSlice(ctx);
+        return this;
+    };
+
+    /**
      * Start to record for a timer.
      *
      * @param timer - The timer needs to be recorded.
-     * @returns Pre.
+     * @returns Env.
      */
     readonly record = (timer: Timer) => {
         timer(this.#clock.store);
+        return this;
+    };
+
+    /**
+     * Clear a timer record.
+     *
+     * @param timer - The timer needs to be cleared.
+     * @returns Env.
+     */
+    readonly clearTimer = (timer: Timer) => {
+        this.#clock.remove(timer);
         return this;
     };
 

--- a/packages/ctx/src/plugin/index.ts
+++ b/packages/ctx/src/plugin/index.ts
@@ -1,5 +1,6 @@
 /* Copyright 2021, Milkdown by Mirone. */
 export * from './ctx';
 export * from './env';
+export * from './post';
 export * from './pre';
 export * from './types';

--- a/packages/ctx/src/plugin/post.ts
+++ b/packages/ctx/src/plugin/post.ts
@@ -1,0 +1,35 @@
+/* Copyright 2021, Milkdown by Mirone. */
+import type { Container, Slice } from '../context';
+import type { Clock, Timer } from '../timing';
+
+export class Post {
+    #container: Container;
+    #clock: Clock;
+
+    constructor(container: Container, clock: Clock) {
+        this.#container = container;
+        this.#clock = clock;
+    }
+
+    /**
+     * Clear a timer record.
+     *
+     * @param timer - The timer needs to be cleared.
+     * @returns Env.
+     */
+    readonly clearTimer = (timer: Timer) => {
+        this.#clock.remove(timer);
+        return this;
+    };
+
+    /**
+     * Remove a context from current editor.
+     *
+     * @param ctx - The context needs to be removed.
+     * @returns Ctx.
+     */
+    readonly remove = <T, N extends string = string>(ctx: Slice<T, N> | N) => {
+        this.#container.removeSlice(ctx);
+        return this;
+    };
+}

--- a/packages/ctx/src/plugin/types.ts
+++ b/packages/ctx/src/plugin/types.ts
@@ -1,9 +1,10 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
 import type { Ctx } from './ctx';
+import type { Post } from './post';
 import type { Pre } from './pre';
 
-export type Cleanup = () => void | Promise<void>;
+export type Cleanup = (post: Post) => void | Promise<void>;
 
 export type HandlerReturnType = void | Promise<void> | Cleanup | Promise<Cleanup>;
 

--- a/packages/ctx/src/plugin/types.ts
+++ b/packages/ctx/src/plugin/types.ts
@@ -3,7 +3,11 @@
 import type { Ctx } from './ctx';
 import type { Pre } from './pre';
 
-export type CtxHandler = (ctx: Ctx) => void | Promise<void>;
+export type Cleanup = () => void | Promise<void>;
+
+export type HandlerReturnType = void | Promise<void> | Cleanup | Promise<Cleanup>;
+
+export type CtxHandler = (ctx: Ctx) => HandlerReturnType;
 
 export type MilkdownPlugin = {
     (pre: Pre): CtxHandler;

--- a/packages/ctx/src/timing/clock.spec.ts
+++ b/packages/ctx/src/timing/clock.spec.ts
@@ -15,4 +15,14 @@ describe('timing/clock', () => {
         expect(clock.get(timer)).toBe(clock.store.get(timer.id));
         expect(() => clock.get(timerNotRegistered)).toThrow();
     });
+
+    it('remove', () => {
+        const clock = createClock();
+        const timer = createTimer('timer');
+        timer(clock.store);
+        expect(clock.get(timer)).toBe(clock.store.get(timer.id));
+
+        clock.remove(timer);
+        expect(() => clock.get(timer)).toThrow();
+    });
 });

--- a/packages/ctx/src/timing/clock.ts
+++ b/packages/ctx/src/timing/clock.ts
@@ -8,6 +8,7 @@ export type ClockMap = Map<symbol, Timing>;
 export type Timer = {
     (store: ClockMap): Timing;
     id: symbol;
+    timerName: string;
 };
 
 export type Clock = {
@@ -20,7 +21,7 @@ export const createClock = (): Clock => {
     const store: ClockMap = new Map();
     const get = (timer: Timer) => {
         const meta = store.get(timer.id);
-        if (!meta) throw timerNotFound(timer.name);
+        if (!meta) throw timerNotFound(timer.timerName);
         return meta;
     };
 

--- a/packages/ctx/src/timing/clock.ts
+++ b/packages/ctx/src/timing/clock.ts
@@ -13,6 +13,7 @@ export type Timer = {
 export type Clock = {
     store: ClockMap;
     get: (timer: Timer) => Timing;
+    remove: (timer: Timer) => void;
 };
 
 export const createClock = (): Clock => {
@@ -23,8 +24,13 @@ export const createClock = (): Clock => {
         return meta;
     };
 
+    const remove = (timer: Timer) => {
+        store.delete(timer.id);
+    };
+
     return {
         store,
         get,
+        remove,
     };
 };

--- a/packages/ctx/src/timing/timing.ts
+++ b/packages/ctx/src/timing/timing.ts
@@ -43,6 +43,7 @@ export const createTimer = (name: string, timeout = 3000): Timer => {
         return timing;
     };
     timer.id = id;
+    timer.timerName = name;
 
     return timer;
 };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

This feature is designed to make plugins can be removed.

Closes: https://github.com/Saul-Mirone/milkdown/issues/442

## API

```typescript
import { myPlugin } from 'my-plugin';

let editor;

// after created
editor = await Editor.make()
  .use(myPlugin)
  .create();

await editor.remove(myPlugin)

// before created

editor = await Editor.make()
  .use(myPlugin)
  .remove(myPlugin);
```

## Post Progress for Plugin

Plugin now can do cleanup it's state in a new `post` progress.

```typescript
const plugin: MilkdownPlugin = (pre) => {
  // pre progress
  return (ctx) => {
    // run progress
    return (post) => {
      // post progress
    }
  }
}
```

The post progress will execute when editor trying to remove the plugin.

## Destroy

Since we have a `remove` method for editor, it'll also bring us the `destroy` feature automatically by remove all plugins.

```typescript
editor = await Editor.make().use(/*...*/).create();

await editor.destroy();
```

## Editor Status

Users now can peek the editor status by call `editor.status`

The possible values are:

```typescript
export enum EditorStatus {
    Init = 'Init',
    Running = 'Running',
    Destroyed = 'Destroyed',
}
```