### PR TITLE
fix: 🐛 add relative position to milkdown-menu-wrapper

### DIFF
--- a/packages/plugin-menu/src/menubar.ts
+++ b/packages/plugin-menu/src/menubar.ts
@@ -81,6 +81,15 @@ export const menubar = (
         if (editorWrapperStyle) {
             editorDOM.classList.add(editorWrapperStyle);
         }
+        const menuWrapperStyle = utils.getStyle(({ css }) => {
+            const style = css`
+                position: relative;
+            `;
+            return style;
+        }) as string;
+        if (menuWrapper) {
+            menuWrapper.classList.add(menuWrapperStyle);
+        }
         const menuStyle = utils.getStyle(({ css }) => {
             const border = themeManager.get(ThemeBorder, undefined);
             const scrollbar = themeManager.get(ThemeScrollbar, ['x', 'thin']);


### PR DESCRIPTION
-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

This PR aims to make it convenient for users to simply install milkdown and not worry about fixing layout issues.

Currently new installations of milkdown encounters a similar bug similar to #587. The issue can be solved by adding the following code to css:

```css
.milkdown-menu-wrapper {
    position: relative;
}
```

For proof here is an image of newly installed milkdown showing the said bug.

<img width="255" alt="image" src="https://user-images.githubusercontent.com/47680867/192533711-c8e45641-43d8-418c-a864-1a7de88ab693.png">

I know a fix [922ab28](https://github.com/Saul-Mirone/milkdown/commit/922ab286f6c27dd8d50a49a7be445e37c5674737) was released to solve the issue but the issue is still happening on newly installed milkdown package. Furthermore, the issue is not seen on [milkdown website](https://milkdown.dev/online-demo) because `.milkdown-menu-wrapper` has `position: relative;` applied.

## How did you test this change?

Started doc server locally and navigate to `/online-demo` route and confirmed that an emotion generated class name is present with `position: relative;` is present.
<img width="516" alt="image" src="https://user-images.githubusercontent.com/47680867/192536236-17b872d9-ba4e-4b47-95db-8d97ef955461.png">

Running the following commands also show no errors:

- `pnpm test` passed.
- `pnpm build:packs` passed.
- `pnpm build:doc` passed.
- `pnpm doc:preview` works as expected.
