### PR TITLE
fix: 🐛 Undo Redo broken with CapsLock

### DIFF
--- a/packages/plugin-history/src/index.ts
+++ b/packages/plugin-history/src/index.ts
@@ -13,7 +13,9 @@ export const historyPlugin = createPlugin(() => ({
         prosemirrorHistory(),
         createKeymap({
             'Mod-z': undo,
+            'Mod-Z': undo,
             'Mod-y': redo,
+            'Mod-Y': redo,
             'Shift-Mod-z': redo,
         }),
     ],


### PR DESCRIPTION
## Summary
[Undo Redo broken with Caps Lock](https://discuss.prosemirror.net/t/undo-redo-broken-with-caps-lock-on-website-demo/4068)

## How did you test this change?
By manually.
