### PR TITLE
fix: 🐛 emoji-filter-position

### DIFF
--- a/packages/plugin-emoji/src/filter/index.ts
+++ b/packages/plugin-emoji/src/filter/index.ts
@@ -156,7 +156,7 @@ export const filter = (utils: ThemeUtils, maxListSize: number, twemojiOptions?: 
                         },
                         twemojiOptions,
                     );
-                    calculateNodePosition(view, dropDown, (selected, target, parent) => {
+                    calculateNodePosition(view, dropDown, (_selected, target, parent) => {
                         const $editor = dropDown.parentElement;
                         if (!$editor) {
                             throw missingRootElement();
@@ -168,29 +168,23 @@ export const filter = (utils: ThemeUtils, maxListSize: number, twemojiOptions?: 
                             left = 0;
                         }
 
-                        const scrollbarWidth = $editor.offsetWidth - $editor.clientWidth;
-                        const maxLeft = parent.width - scrollbarWidth - (target.width + 4);
-                        if (left > maxLeft) {
-                            left = maxLeft;
-                        }
-
                         let direction: 'top' | 'bottom';
                         let maxHeight: number | undefined;
-                        const selectedToTop = selected.top - parent.top;
-                        const selectedToBottom = parent.height + parent.top - selected.bottom;
-                        if (selectedToBottom >= target.height + 28) {
+                        const startToTop = start.top - parent.top;
+                        const startToBottom = parent.height + parent.top - start.bottom;
+                        if (startToBottom >= target.height + 28) {
                             direction = 'bottom';
-                        } else if (selectedToTop >= target.height + 28) {
+                        } else if (startToTop >= target.height + 28) {
                             direction = 'top';
-                        } else if (selectedToBottom >= selectedToTop) {
+                        } else if (startToBottom >= startToTop) {
                             direction = 'bottom';
-                            maxHeight = selectedToBottom - 28;
+                            maxHeight = startToBottom - 28;
                         } else {
                             direction = 'top';
-                            maxHeight = selectedToTop - 28;
+                            maxHeight = startToTop - 28;
                         }
-                        if (selectedToTop < 0 || selectedToBottom < 0) {
-                            maxHeight = parent.height - selected.height - 28;
+                        if (startToTop < 0 || startToBottom < 0) {
+                            maxHeight = parent.height - (start.bottom - start.top) - 28;
                             if (maxHeight > target.height) {
                                 maxHeight = undefined;
                             }
@@ -198,10 +192,15 @@ export const filter = (utils: ThemeUtils, maxListSize: number, twemojiOptions?: 
 
                         const top =
                             direction === 'top'
-                                ? selected.top - parent.top - (maxHeight ?? target.height) - 14 + $editor.scrollTop
-                                : selected.bottom - parent.top + 14 + $editor.scrollTop;
+                                ? start.top - parent.top - (maxHeight ?? target.height) - 14 + $editor.scrollTop
+                                : start.bottom - parent.top + 14 + $editor.scrollTop;
 
                         dropDown.style.maxHeight = maxHeight !== undefined && maxHeight > 0 ? `${maxHeight}px` : '';
+
+                        const maxLeft = $editor.clientWidth - (dropDown.offsetWidth + 4);
+                        if (left > maxLeft) {
+                            left = maxLeft;
+                        }
 
                         return [top, left];
                     });

--- a/packages/plugin-tooltip/src/button-manager/calc-button-pos.ts
+++ b/packages/plugin-tooltip/src/button-manager/calc-button-pos.ts
@@ -16,8 +16,7 @@ export const calcButtonPos = (buttons: HTMLElement, view: EditorView, isBottom: 
 
         if (left < 0) left = 0;
 
-        const scrollbarWidth = $editor.offsetWidth - $editor.clientWidth;
-        const maxLeft = parent.width - scrollbarWidth - (target.width + 4);
+        const maxLeft = $editor.clientWidth - (target.width + 4);
         if (left > maxLeft) {
             left = maxLeft;
         }

--- a/packages/preset-commonmark/src/mark/link.ts
+++ b/packages/preset-commonmark/src/mark/link.ts
@@ -128,8 +128,7 @@ export const link = createMark<string, LinkOptions>((utils, options) => {
 
                                     if (left < 0) left = 0;
 
-                                    const scrollbarWidth = $editor.offsetWidth - $editor.clientWidth;
-                                    const maxLeft = parent.width - scrollbarWidth - (target.width + 4);
+                                    const maxLeft = $editor.clientWidth - (target.width + 4);
                                     if (left > maxLeft) {
                                         left = maxLeft;
                                     }

--- a/packages/preset-gfm/src/table/operator-plugin/calc-pos.ts
+++ b/packages/preset-gfm/src/table/operator-plugin/calc-pos.ts
@@ -25,8 +25,7 @@ export const calculatePosition = (view: EditorView, dom: HTMLElement) => {
             left = 0;
         }
 
-        const scrollbarWidth = $editor.offsetWidth - $editor.clientWidth;
-        const maxLeft = parent.width - scrollbarWidth - (target.width + 4);
+        const maxLeft = $editor.clientWidth - (target.width + 4);
         if (left > maxLeft) {
             left = maxLeft;
         }

--- a/packages/theme-pack-helper/src/renderer-preset/input-chip.ts
+++ b/packages/theme-pack-helper/src/renderer-preset/input-chip.ts
@@ -88,8 +88,7 @@ const calcInputPos = (view: EditorView, input: HTMLDivElement) => {
 
         if (left < 0) left = 0;
 
-        const scrollbarWidth = $editor.offsetWidth - $editor.clientWidth;
-        const maxLeft = parent.width - scrollbarWidth - (target.width + 4);
+        const maxLeft = $editor.clientWidth - (target.width + 4);
         if (left > maxLeft) {
             left = maxLeft;
         }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

I'm sorry for some problems created in #801.

**Bugs:**

1. Emoji Filter left position does not calculate the scrollbar inside the Filter, causing the editor to have a scrollbar.

<img width="1157" alt="image" src="https://user-images.githubusercontent.com/2498173/200784910-59dd01af-eb2d-47bc-9c3d-9369f2cb6896.png">

2. The top position of Filter is wrong when entering emoji in multi-line text.

<img width="1163" alt="image" src="https://user-images.githubusercontent.com/2498173/200785909-c3138b9b-42cd-4ca2-b2ad-83271ac36151.png">

https://milkdown-git-fork-ihapboy-feat-optimize-emoj-8d4d31-saul-mirone.vercel.app/online-demo?text=EYYwJgBAhqY%2B1aPPSrlye12u1wjnofnhAFwDOAtgFC3GYnNNqMFsqMYc%2FdEsIARwDuAUz6CBnGb2kZJMxQvkEIw8co5zSU3UtXt%2BWSnDSmAllFEB7CVEoQjeri9Yr9H1wc%2Fbuo%2B19nH28vdz83HVC1AK1gsKjw%2BNwKR2j%2BUyhzMCtbe0dkwpZEkuN04v9NQwrIsqSakPrZMo1A8ubazsbSt2hM7NyROz76UbHxsaA%3D%3D%3D

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

1. Test cases:

<img width="1163" alt="image" src="https://user-images.githubusercontent.com/2498173/200786399-5fdb3c4a-0475-4c26-8814-21ec62bdc0a1.png">

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/2498173/200786535-e79c9303-ad5d-4ca8-8c2b-d59a1412219d.png">

2. Running the following commands also show no errors:

-   `pnpm test` passed.
-   `pnpm build:packs` passed.
-   `pnpm build:doc` passed.
-   `pnpm doc:preview` works as you expected.

