### PR TITLE
feat: 🎸 add an option to show input chip when selected for link

### DIFF
--- a/packages/preset-commonmark/src/mark/link.ts
+++ b/packages/preset-commonmark/src/mark/link.ts
@@ -15,8 +15,9 @@ export const ModifyLink = createCmdKey<string>('ModifyLink');
 const id = 'link';
 export type LinkOptions = {
     input: {
-        placeholder: string;
+        placeholder?: string;
         buttonText?: string;
+        displayWhenSelected?: boolean;
     };
 };
 export const link = createMark<string, LinkOptions>((utils, options) => {
@@ -147,14 +148,30 @@ export const link = createMark<string, LinkOptions>((utils, options) => {
                             }
 
                             if (
-                                selection.empty &&
                                 selection instanceof TextSelection &&
                                 to < doc.content.size &&
                                 from < doc.content.size &&
                                 doc.rangeHasMark(from, from === to ? to + 1 : to, type)
                             ) {
-                                renderOnTop = false;
-                                return true;
+                                let shouldDisplay = selection.empty;
+                                if (options?.input?.displayWhenSelected && !shouldDisplay) {
+                                    doc.nodesBetween(from, from === to ? to + 1 : to, (node, pos) => {
+                                        if (
+                                            node.marks.some(
+                                                (mark) =>
+                                                    mark.type === type && from >= pos && to <= pos + node.nodeSize,
+                                            )
+                                        ) {
+                                            shouldDisplay = true;
+                                            return false;
+                                        }
+                                        return;
+                                    });
+                                }
+                                if (shouldDisplay) {
+                                    renderOnTop = false;
+                                    return true;
+                                }
                             }
 
                             if (selection instanceof NodeSelection) {

--- a/website/pages/official-plugins/preset-commonmark/index.md
+++ b/website/pages/official-plugins/preset-commonmark/index.md
@@ -81,6 +81,13 @@ new Editor({ ...  }).use(nodes);
     -   placeholder: The placeholder of image url input.
     -   buttonText: The button text of image url input.
 
+### Link
+
+-   input:
+    -   placeholder: The placeholder of link url input.
+    -   buttonText: The button text of link url input.
+    -   displayWhenSelected: Whether to display the input chip when the link text is selected.
+
 ### CodeFence
 
 -   languageList: _string[]_. The selectable languages list of code fence needs to be enabled.


### PR DESCRIPTION
✅ Closes: #808

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

1. display input chip when selected for link text
2. add an option `displayWhenSelected` to `link` node (default: `false`)

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

1. Test cases:

```typescript
.use(
    gfm.configure(link, {
        input: {
            displayWhenSelected: true,
        },
    }),
)
```

![input-chip-display-when-selected](https://user-images.githubusercontent.com/2498173/201293111-b849cb12-fddf-4262-8ba5-96ae838857d9.gif)

2. Running the following commands also show no errors:

-   `pnpm test` passed.
-   `pnpm build:packs` passed.
-   `pnpm build:doc` passed.
-   `pnpm doc:preview` works as you expected.
