### PR TITLE
fix: 🐛 emoji filter update active item by mouse event

### DIFF
--- a/packages/plugin-emoji/src/filter/helper.ts
+++ b/packages/plugin-emoji/src/filter/helper.ts
@@ -39,7 +39,6 @@ export const checkTrigger = (
 export const renderDropdownList = (
   list: Emoji[],
   dropDown: HTMLElement,
-  $active: HTMLElement | null,
   onConfirm: () => void,
   setActive: (active: HTMLElement | null) => void,
   twemojiOptions?: TwemojiOptions,
@@ -63,27 +62,14 @@ export const renderDropdownList = (
     container.appendChild(keySpan)
     dropDown.appendChild(container)
 
-    if (i === 0) {
-      container.classList.add('active')
+    if (i === 0)
       setActive(container)
-    }
 
     const onEnter = (e: MouseEvent) => {
-      if ($active)
-        $active.classList.remove('active')
-
       const { target } = e
       if (!(target instanceof HTMLElement))
         return
-      target.classList.add('active')
       setActive(target)
-    }
-
-    const onLeave = (e: MouseEvent) => {
-      const { target } = e
-      if (!(target instanceof HTMLElement))
-        return
-      target.classList.remove('active')
     }
 
     const onClick = (e: MouseEvent) => {
@@ -92,7 +78,6 @@ export const renderDropdownList = (
     }
 
     container.addEventListener('mouseenter', onEnter)
-    container.addEventListener('mouseleave', onLeave)
     container.addEventListener('mousedown', onClick)
   })
 }

--- a/packages/plugin-emoji/src/filter/index.ts
+++ b/packages/plugin-emoji/src/filter/index.ts
@@ -24,6 +24,16 @@ export const filter = (utils: ThemeUtils, maxListSize: number, twemojiOptions?: 
     $active = null
   }
 
+  const setActive = (active: HTMLElement | null) => {
+    if ($active)
+      $active.classList.remove('active')
+
+    if (active)
+      active.classList.add('active')
+
+    $active = active
+  }
+
   return new Plugin({
     key,
     props: {
@@ -106,16 +116,12 @@ export const filter = (utils: ThemeUtils, maxListSize: number, twemojiOptions?: 
 
         if (['ArrowDown', 'ArrowUp'].includes(key)) {
           const next
-                        = key === 'ArrowDown'
-                          ? $active?.nextElementSibling || dropDown.firstElementChild
-                          : $active?.previousElementSibling || dropDown.lastElementChild
-          if ($active)
-            $active.classList.remove('active')
-
+            = key === 'ArrowDown'
+              ? $active?.nextElementSibling || dropDown.firstElementChild
+              : $active?.previousElementSibling || dropDown.lastElementChild
           if (!next)
             return
-          next.classList.add('active')
-          $active = next as HTMLElement
+          setActive(next as HTMLElement)
         }
       }
       const onClick = (e: Event) => {
@@ -147,16 +153,7 @@ export const filter = (utils: ThemeUtils, maxListSize: number, twemojiOptions?: 
 
           dropDown.style.maxHeight = ''
           dropDown.classList.remove('hide')
-          renderDropdownList(
-            result,
-            dropDown,
-            $active,
-            replace,
-            (a) => {
-              $active = a
-            },
-            twemojiOptions,
-          )
+          renderDropdownList(result, dropDown, replace, setActive, twemojiOptions)
           calculateNodePosition(view, dropDown, (_selected, target, parent) => {
             const $editor = dropDown.parentElement
             if (!$editor)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

**Bug:** mouse enter/leave can't update active item.

![emoji-filter-active-before](https://user-images.githubusercontent.com/2498173/201890574-1f77e033-bc09-4da1-99e9-2a0d5fff97dd.gif)

**Fixed:**

![emoji-filter-active-active](https://user-images.githubusercontent.com/2498173/201890677-cbfdc663-648d-45a7-b517-d8681faf2970.gif)

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
