### PR TITLE
fix: 🐛 hide slash placeholder when editable is false

### DIFF
--- a/packages/plugin-slash/src/config.ts
+++ b/packages/plugin-slash/src/config.ts
@@ -1,6 +1,6 @@
 /* Copyright 2021, Milkdown by Mirone. */
 import type { Ctx } from '@milkdown/core'
-import { commandsCtx, schemaCtx, themeManagerCtx } from '@milkdown/core'
+import { commandsCtx, editorViewCtx, schemaCtx, themeManagerCtx } from '@milkdown/core'
 import type { Node } from '@milkdown/prose/model'
 import type { EditorState } from '@milkdown/prose/state'
 
@@ -117,6 +117,10 @@ export const defaultActions = (ctx: Ctx, input = '/'): WrappedAction[] => {
 export const defaultConfig: Config = (ctx) => {
   return ({ content, isTopLevel }) => {
     if (!isTopLevel)
+      return null
+
+    const view = ctx.get(editorViewCtx)
+    if (!view?.editable)
       return null
 
     if (!content)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

**Bug:** Slash placeholder is also displayed when `editable` is `false`

![slash-editable-before](https://user-images.githubusercontent.com/2498173/201904531-efdef118-cc27-40d8-884c-8c914cd7fd79.gif)

**Fixed:**

![slash-editable-after](https://user-images.githubusercontent.com/2498173/201904510-013006c8-e71b-4d92-9ad3-de076af967a7.gif)

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
