### PR TITLE
fix: 🐛 disable table operator when editable is false

### DIFF
--- a/packages/preset-gfm/src/table/operator-plugin/index.ts
+++ b/packages/preset-gfm/src/table/operator-plugin/index.ts
@@ -1,6 +1,7 @@
 /* Copyright 2021, Milkdown by Mirone. */
 
 import type { Ctx } from '@milkdown/core'
+import { editorViewCtx } from '@milkdown/core'
 import { Plugin, PluginKey } from '@milkdown/prose/state'
 import type { Decoration } from '@milkdown/prose/view'
 import { DecorationSet } from '@milkdown/prose/view'
@@ -23,6 +24,10 @@ export const operatorPlugin = (ctx: Ctx, utils: ThemeUtils) => {
     key: new PluginKey('MILKDOWN_TABLE_OP'),
     props: {
       decorations: (state) => {
+        const view = ctx.get(editorViewCtx)
+        if (!view.editable)
+          return null
+
         const decorations: Decoration[] = []
         const leftCells = getCellsInColumn(0)(state.selection)
         if (!leftCells)

--- a/packages/preset-gfm/src/table/plugin/column-resizing.ts
+++ b/packages/preset-gfm/src/table/plugin/column-resizing.ts
@@ -38,12 +38,18 @@ export function columnResizing({
 
       handleDOMEvents: {
         mousemove(view, event) {
+          if (!view.editable)
+            return
           handleMouseMove(view, event as MouseEvent, handleWidth, lastColumnResizable)
         },
         mouseleave(view) {
+          if (!view.editable)
+            return
           handleMouseLeave(view)
         },
         mousedown(view, event) {
+          if (!view.editable)
+            return
           handleMouseDown(view, event as MouseEvent, cellMinWidth)
         },
       },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

**Bug:** Table operator and column resizing handle is also displayed when `editable` is `false`

![table-readonly-before](https://user-images.githubusercontent.com/2498173/202693498-479d6c56-f187-44b5-957c-28ab8ede7256.gif)

**Fixed:**

![table-readonly-after](https://user-images.githubusercontent.com/2498173/202693522-63aedea3-d3eb-48c9-b3c0-43e70842229d.gif)

## How did you test this change?

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
