### PR TITLE
fix(list-item): unstable selection

### DIFF
--- a/packages/components/src/list-item-block/view.ts
+++ b/packages/components/src/list-item-block/view.ts
@@ -36,13 +36,12 @@ export const listItemBlockView = $view(listItemSchema.node, (ctx): NodeViewConst
       view.dispatch(view.state.tr.setNodeAttribute(pos, attr, value))
     }
     dom.onMount = () => {
-      const pos = getPos() ?? 0
-      const end = pos + initialNode.nodeSize
-      const { from, to } = view.state.selection
-      if (view.hasFocus() && pos < from && to < end) {
+      const { anchor, head } = view.state.selection
+      if (view.hasFocus()) {
         Promise.resolve().then(() => {
-          const p = view.state.doc.resolve(pos)
-          view.dispatch(view.state.tr.setSelection(TextSelection.near(p, 1)))
+          const anchorPos = view.state.doc.resolve(anchor)
+          const headPos = view.state.doc.resolve(head)
+          view.dispatch(view.state.tr.setSelection(new TextSelection(anchorPos, headPos)))
         })
       }
     }
@@ -56,7 +55,7 @@ export const listItemBlockView = $view(listItemSchema.node, (ctx): NodeViewConst
           return false
 
         if (updatedNode.sameMarkup(node) && updatedNode.content.eq(node.content))
-          return false
+          return true
 
         node = updatedNode
         bindAttrs(updatedNode)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

-   [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
-   [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

List item selection is unstable under certain conditions, preventing smooth input.
This PR fixes several issues.

First, when IME composing, the caret moves to the head of the line. This was due to the composition end event causing unnecessary re-rendering.

Next, when multiple list items were selected and the Tab key was pressed, there was a problem where the selection would move. So when the list items were re-rendered, this was taken into account.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

I reproduced the problem on a storyboard and confirmed that it was solved.
I have done all the bullet, ordered and todo list types.

✅ Windows11 Edge
✅ Windows11 Chrome
✅ Windows11 FireFox
✅ macOS 14 Safari
✅ macOS 14 Chrome
✅ macOS 14 Edge
✅ macOS 14 FireFox

IME composing
| Before | After |
| --- | --- |
| ![japanese](https://github.com/user-attachments/assets/c1abe15e-3467-4176-87d6-c12711e7a909) | ![fix-japanese](https://github.com/user-attachments/assets/d9c73a68-99e0-4183-acfd-e1a88c276114) |

Shift-Tab → Tab
| Before | After |
| --- | --- |
| ![selection](https://github.com/user-attachments/assets/0bf6c245-4c10-4388-b515-a6b3935086ad) | ![fix-selection](https://github.com/user-attachments/assets/5cea4e6d-82bf-4fac-87f3-d59da9b90a30) |

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->
