### PR TITLE
fix: 🐛 config merge should not merge array in crepe

### DIFF
--- a/packages/crepe/src/default-config/default-config.spec.ts
+++ b/packages/crepe/src/default-config/default-config.spec.ts
@@ -1,0 +1,27 @@
+import type { LanguageDescription } from '@codemirror/language'
+
+import { expect, test } from 'vitest'
+
+import { applyConfig } from '.'
+import { CrepeFeature } from '../feature'
+
+const mockHSLanguageDescription = {
+  name: 'haskell',
+} as LanguageDescription
+
+const mockCppLanguageDescription = {
+  name: 'cpp',
+} as LanguageDescription
+
+test('should use custom config to override the default config', () => {
+  const myConfig = applyConfig({
+    [CrepeFeature.CodeMirror]: {
+      languages: [mockHSLanguageDescription, mockCppLanguageDescription],
+    },
+  })
+
+  expect(myConfig[CrepeFeature.CodeMirror]?.languages).toEqual([
+    mockHSLanguageDescription,
+    mockCppLanguageDescription,
+  ])
+})

--- a/packages/crepe/src/default-config/index.ts
+++ b/packages/crepe/src/default-config/index.ts
@@ -1,5 +1,6 @@
 import { languages } from '@codemirror/language-data'
 import { oneDark } from '@codemirror/theme-one-dark'
+import { mergeWith } from 'lodash-es'
 
 import { CrepeFeature, type CrepeFeatureConfig } from '../feature'
 import {
@@ -22,4 +23,13 @@ export const defaultConfig: CrepeFeatureConfig = {
     previewToggleIcon: (previewOnlyMode) =>
       previewOnlyMode ? editIcon : visibilityOffIcon,
   },
+}
+
+export const applyConfig = (userConfig: Partial<CrepeFeatureConfig>) => {
+  return mergeWith({}, defaultConfig, userConfig, (_objValue, srcValue) => {
+    if (Array.isArray(srcValue)) {
+      return srcValue
+    }
+    return undefined
+  })
 }


### PR DESCRIPTION
✅ Closes: #2064

<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

Should not merge array in crepe for config merge.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?

CI

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

- `main` <!-- branch-stack -->
  - \#2066 :point\_left:
