### PR TITLE
fix(crepe): Submit button on the inline edit confirm

### DIFF
--- a/packages/crepe/src/feature/latex/inline-tooltip/component.tsx
+++ b/packages/crepe/src/feature/latex/inline-tooltip/component.tsx
@@ -47,7 +47,7 @@ export const LatexTooltip = defineComponent<LatexTooltipProps>({
       return (
         <div class="container">
           {props.innerView && <div ref={innerViewRef} />}
-          <button onPointerdown={onUpdate}>
+          <button type="button" onPointerdown={onUpdate}>
             <Icon icon={props.config.inlineEditConfirm} />
           </button>
         </div>


### PR DESCRIPTION
- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary
When editing a latex formula, the button to confirm doesn't have an explicit type="button" which defaults to submit which, when used within a `<form>`, results in a form submission. 

✅ Closes: #2162

## How did you test this change?
Tested with `pnpm test` and storybook + element inspector.
