### PR TITLE
fix: use divs instead of nested buttons

### DIFF
--- a/packages/components/src/table-block/view/component.tsx
+++ b/packages/components/src/table-block/view/component.tsx
@@ -119,8 +119,7 @@ export const TableBlock = defineComponent<TableBlockProps>({
           onPointermove={pointerMove}
           onPointerleave={pointerLeave}
         >
-          <button
-            type="button"
+          <div
             data-show="false"
             contenteditable="false"
             draggable="true"
@@ -151,9 +150,8 @@ export const TableBlock = defineComponent<TableBlockProps>({
                 <Icon icon={config.renderButton('delete_col')} />
               </button>
             </div>
-          </button>
-          <button
-            type="button"
+          </div>
+          <div
             data-show="false"
             contenteditable="false"
             draggable="true"
@@ -175,7 +173,7 @@ export const TableBlock = defineComponent<TableBlockProps>({
                 <Icon icon={config.renderButton('delete_row')} />
               </button>
             </div>
-          </button>
+          </div>
           <div class="table-wrapper" ref={tableWrapperRef}>
             <div
               data-show="false"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [X] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [X] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary
Fix nested <button> tags in the table component to prevent browser warnings and improve accessibility.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

## How did you test this change?
Tested dependency update in my local pnpm workspace environment and verified that adding, deleting, and dragging rows/columns still work.
<img width="1312" height="611" alt="image" src="https://github.com/user-attachments/assets/3d0ddac8-a2cb-4012-87b5-bab8a0260e61" />

<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!-- branch-stack -->
