### PR TITLE
fix: previewLabel was always hidden

### DIFF
--- a/packages/components/src/code-block/view/components/preview-panel.tsx
+++ b/packages/components/src/code-block/view/components/preview-panel.tsx
@@ -67,9 +67,7 @@ export const PreviewPanel = defineComponent<PreviewPanelProps>({
           {!previewOnlyMode.value && (
             <>
               <div class="preview-divider" />
-              <div class="preview-label" >
-                {config.previewLabel}
-              </div>
+              <div class="preview-label">{config.previewLabel}</div>
             </>
           )}
           <div ref={previewRef} class="preview" />


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [X] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [X] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary

This PR fixes an issue where the preview label was always hidden, even when preview mode was enabled.

## How did you test this change?
Tested dependency update in my local pnpm workspace env.
<img width="572" height="217" alt="image" src="https://github.com/user-attachments/assets/4a0754a7-491d-4fe1-9e70-08f20b7abae0" />


<!--
  Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface.
  How exactly did you verify that your PR solves the issue you wanted to solve?
  If you leave this empty, your PR will very likely be closed.
-->

<!-- branch-stack -->
