### PR TITLE
fix(plugin-block): add dragend event listener to block handle element

### DIFF
--- a/packages/plugins/plugin-block/src/block-service.ts
+++ b/packages/plugins/plugin-block/src/block-service.ts
@@ -108,6 +108,7 @@ export class BlockService {
     dom.addEventListener('mousedown', this.#handleMouseDown)
     dom.addEventListener('mouseup', this.#handleMouseUp)
     dom.addEventListener('dragstart', this.#handleDragStart)
+    dom.addEventListener('dragend', this.#handleDragEnd)
   }
 
   /// Remove mouse event to the dom.
@@ -115,6 +116,7 @@ export class BlockService {
     dom.removeEventListener('mousedown', this.#handleMouseDown)
     dom.removeEventListener('mouseup', this.#handleMouseUp)
     dom.removeEventListener('dragstart', this.#handleDragStart)
+    dom.removeEventListener('dragend', this.#handleDragEnd)
   }
 
   /// Unbind the notify function.
@@ -168,6 +170,13 @@ export class BlockService {
         slice,
         move: true,
       }
+    }
+  }
+
+  /// @internal
+  #handleDragEnd = () => {
+    if (this.#view) {
+      this.#dragEnd(this.#view)
     }
   }
 


### PR DESCRIPTION
## Summary

Fix the issue where releasing the block drag outside the editor area would not trigger \`#dragEnd\`, causing the \`dataset.dragging\` to remain \`true\` and resulting in no selection background being displayed.

<img width="831" height="450" alt="image" src="https://github.com/user-attachments/assets/6bfae6c7-75f5-4807-9fa3-b52cc45f00cd" />


## Problem

When dragging a block handle and releasing it outside the editor area, the \`dragend\` event on the block handle DOM was not being captured. This caused:
- \`#dragging\` state remained \`true\`
- \`view.dom.dataset.dragging\` stayed as \`'true'\`
- Selection background styles were not applied correctly

## Solution

Added \`dragend\` event listener to the block handle element to properly reset the dragging state when the drag operation ends, regardless of where the mouse is released.

## Changes

- Added \`dragend\` event listener in \`addEvent\` method
- Added corresponding event removal in \`removeEvent\` method  
- Added \`#handleDragEnd\` handler that calls \`#dragEnd\` to reset the dragging state