### PR TITLE
fix: simplify icon rendering by removing unnecessary ref and using innerHTML directly

### DIFF
--- a/packages/components/src/__internal__/components/icon.tsx
+++ b/packages/components/src/__internal__/components/icon.tsx
@@ -2,6 +2,8 @@ import clsx from 'clsx'
 import DOMPurify from 'dompurify'
 import { h } from 'vue'
 
+h
+
 type IconProps = {
   icon?: string | null
   class?: string
@@ -13,7 +15,7 @@ export function Icon({ icon, class: className, onClick }: IconProps) {
     <span
       class={clsx('milkdown-icon', className)}
       onPointerdown={onClick}
-      innerHTML={icon ? DOMPurify.sanitize(icon.trim()): undefined}
+      innerHTML={icon ? DOMPurify.sanitize(icon.trim()) : undefined}
     />
   )
 }


### PR DESCRIPTION
[x] I read the contributing guide
[x] I agree to follow the code of conduct

## Summary

I use @vue/cli-service@5, and get the warning, and the icon does not render.

> [Vue warn]: Missing ref owner context. ref cannot be used on hoisted vnodes. A vnode with ref must be created inside the render function

## How did you test this change?

By patch-package to change it, and it rendered successful

patched file \`node_modules/@milkdown/components/lib/index.js\`

```js
import clsx from 'clsx';
import DOMPurify from 'dompurify';
import { h } from 'vue';

function Icon({ icon, class: className, onClick }) {
  return /* @__PURE__ */ h(
    "span",
    {
      class: clsx("milkdown-icon", className),
      onPointerdown: onClick,
      innerHTML: icon ? DOMPurify.sanitize(icon) : undefined,
    }
  );
}
Icon.props = {
  icon: {
    type: String,
    required: false
  },
  class: {
    type: String,
    required: false
  },
  onClick: {
    type: Function,
    required: false
  }
};

export { Icon };
//# sourceMappingURL=index.js.map

export { Icon };
//# sourceMappingURL=index.js.map
```

---

**Note:** Sorry for the confusion with the previous PR #2195. I accidentally pushed to the wrong branch (main instead of a feature branch), and I reset `main` branch to upstream, so PR #2195 closed automatically. This PR contains the same fix but from the correct feature branch.