### PR TITLE
feat: tooltip auto update

### DIFF
--- a/packages/components/src/link-tooltip/edit/edit-view.ts
+++ b/packages/components/src/link-tooltip/edit/edit-view.ts
@@ -110,10 +110,10 @@ export class LinkEditTooltip implements PluginView {
     view.dispatch(
       view.state.tr.setSelection(TextSelection.create(view.state.doc, from, to))
     )
-    this.#provider.show({
-      getBoundingClientRect: () => posToDOMRect(view, from, to),
-      contextElement: view.dom,
-    })
+    this.#provider.show(
+      { getBoundingClientRect: () => posToDOMRect(view, from, to) },
+      view
+    )
     requestAnimationFrame(() => {
       this.#content.querySelector('input')?.focus()
     })

--- a/packages/components/src/link-tooltip/preview/preview-view.ts
+++ b/packages/components/src/link-tooltip/preview/preview-view.ts
@@ -79,10 +79,7 @@ export class LinkPreviewTooltip implements PluginView {
       this.#hide()
     }
 
-    this.#provider.show({
-      getBoundingClientRect: () => rect,
-      contextElement: this.#editorView.dom,
-    })
+    this.#provider.show({ getBoundingClientRect: () => rect }, this.#editorView)
     this.#provider.element.addEventListener('mouseenter', this.#onMouseEnter)
     this.#provider.element.addEventListener('mouseleave', this.#onMouseLeave)
   }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!
We appreciate you spending the time to work on these changes.

⚠️ If you're adding a new plugin, please make sure you've already created issues or discussions where we have discussed about it. Currently we encourage you to publish your own community plugins. And we're very cautious about adding new official plugins.
-->

- [x] I read the contributing guide <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CONTRIBUTING.md -->
- [x] I agree to follow the code of conduct <!-- https://github.com/Saul-Mirone/milkdown/blob/main/CODE_OF_CONDUCT.md -->

## Summary
Add `autoUpdate` for tooltip

## How did you test this change?
Make a selection to make tooltip show (mounted outside the dom, maybe the `<body>`), and scroll the document(which is `overflow:auto`):

Before:

<img width="496" height="294" alt="image" src="https://github.com/user-attachments/assets/fa1b0c8a-29a2-45b7-97ef-1a2b336d4557" />

After:
<img width="454" height="237" alt="image" src="https://github.com/user-attachments/assets/e3226b2e-3ef6-4326-8e72-8fa37db251c6" />



