### PR TITLE
fix(preset-gfm): add empty content guard to table_header_row serializer

### DIFF
--- a/packages/plugins/preset-gfm/src/__test__/table-header-row.spec.ts
+++ b/packages/plugins/preset-gfm/src/__test__/table-header-row.spec.ts
@@ -1,0 +1,64 @@
+import '@testing-library/jest-dom/vitest'
+import {
+  defaultValueCtx,
+  Editor,
+  editorViewCtx,
+  schemaCtx,
+  serializerCtx,
+} from '@milkdown/core'
+import { commonmark } from '@milkdown/preset-commonmark'
+import { expect, it } from 'vitest'
+
+import { gfm } from '..'
+
+function createEditor() {
+  const editor = Editor.make()
+  editor.use(commonmark)
+  editor.use(gfm)
+  return editor
+}
+
+it('should not crash when serializing a table with empty header row', async () => {
+  const markdown = `| head |\n| --- |\n| cell |\n`
+  const editor = createEditor()
+  editor.config((ctx) => {
+    ctx.set(defaultValueCtx, markdown)
+  })
+
+  await editor.create()
+
+  const schema = editor.ctx.get(schemaCtx)
+  const serializer = editor.ctx.get(serializerCtx)
+
+  // Create a table with an empty header row (content.size === 0)
+  const tableHeaderRow = schema.nodes.table_header_row!.create()
+  const tableRow = schema.nodes.table_row!.create(null, [
+    schema.nodes.table_cell!.create(
+      null,
+      schema.nodes.paragraph!.create(null, schema.text('cell'))
+    ),
+  ])
+  const table = schema.nodes.table!.create(null, [tableHeaderRow, tableRow])
+  const doc = schema.topNodeType.createAndFill(null, [table])!
+
+  // This should not throw
+  expect(() => serializer(doc)).not.toThrow()
+})
+
+it('should serialize a normal table correctly', async () => {
+  const markdown = `| head |\n| --- |\n| cell |\n`
+  const editor = createEditor()
+  editor.config((ctx) => {
+    ctx.set(defaultValueCtx, markdown)
+  })
+
+  await editor.create()
+
+  const view = editor.ctx.get(editorViewCtx)
+  const serializer = editor.ctx.get(serializerCtx)
+
+  // Serializing the current doc (which has a normal table) should work
+  const result = serializer(view.state.doc)
+  expect(result).toContain('head')
+  expect(result).toContain('cell')
+})

--- a/packages/plugins/preset-gfm/src/__test__/vitest.setup.ts
+++ b/packages/plugins/preset-gfm/src/__test__/vitest.setup.ts
@@ -1,0 +1,65 @@
+// Mock missing DOM APIs that ProseMirror needs but JSDOM doesn't provide
+
+// Mock elementFromPoint
+if (!document.elementFromPoint) {
+  document.elementFromPoint = () => null
+}
+
+// Mock getClientRects for all elements
+Object.defineProperty(Element.prototype, 'getClientRects', {
+  value: function () {
+    return {
+      length: 0,
+      item: () => null,
+      [Symbol.iterator]: function* () {},
+    }
+  },
+})
+
+Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+  value: function () {
+    return {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      toJSON: () => ({}),
+    }
+  },
+})
+
+// Mock Range methods
+Object.defineProperty(Range.prototype, 'getClientRects', {
+  value: function () {
+    return {
+      length: 0,
+      item: () => null,
+      [Symbol.iterator]: function* () {},
+    }
+  },
+})
+
+Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+  value: function () {
+    return {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      toJSON: () => ({}),
+    }
+  },
+})
+
+// Mock scrollIntoView
+Object.defineProperty(Element.prototype, 'scrollIntoView', {
+  value: function () {},
+})

--- a/packages/plugins/preset-gfm/src/node/table/schema.ts
+++ b/packages/plugins/preset-gfm/src/node/table/schema.ts
@@ -104,6 +104,11 @@ export const tableHeaderRowSchema = $nodeSchema('table_header_row', () => ({
   toMarkdown: {
     match: (node) => node.type.name === 'table_header_row',
     runner: (state, node) => {
+      // if the row is empty, we don't need to create a table row
+      // prevent remark from crashing
+      if (node.content.size === 0) {
+        return
+      }
       state.openNode('tableRow', undefined, { isHeader: true })
       state.next(node.content)
       state.closeNode()

--- a/packages/plugins/preset-gfm/vitest.config.ts
+++ b/packages/plugins/preset-gfm/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/__test__/vitest.setup.ts'],
+  },
+})


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

`table_header_row`'s serializer crashes when the header row has empty content (`node.content.size === 0`). The `table_row` serializer already has a guard for this case, but `table_header_row` was missing it, causing `mdast-util-gfm-table` to throw `TypeError: Cannot read properties of undefined (reading 'length')`.

This adds the same empty content guard to `table_header_row`.

Closes #2271

## How did you test this change?

Added a test that constructs a table with an empty header row and verifies serialization doesn't throw:

- Without the fix: `TypeError: Cannot read properties of undefined (reading 'length')`
- With the fix: serialization completes without error