### PR TITLE
fix(transformer): inline code with bold/italic marks produces wrong markdown

### DIFF
--- a/packages/plugins/preset-commonmark/src/mark/inline-code.ts
+++ b/packages/plugins/preset-commonmark/src/mark/inline-code.ts
@@ -38,6 +38,7 @@ export const inlineCodeSchema = $markSchema('inlineCode', (ctx) => ({
     match: (mark) => mark.type.name === 'inlineCode',
     runner: (state, mark, node) => {
       state.withMark(mark, 'inlineCode', node.text || '')
+      return true
     },
   },
 }))

--- a/packages/transformer/src/serializer/state.spec.ts
+++ b/packages/transformer/src/serializer/state.spec.ts
@@ -20,6 +20,14 @@ const italicMark = {
   },
 } as unknown as Mark
 
+const inlineCodeMark = {
+  isInSet: (arr: string[]) => arr.includes('inlineCode'),
+  addToSet: (arr: string[]) => arr.concat('inlineCode'),
+  type: {
+    removeFromSet: (arr: string[]) => arr.filter((x) => x !== 'inlineCode'),
+  },
+} as unknown as Mark
+
 const schema = {
   nodes: {
     paragraph: {
@@ -190,6 +198,50 @@ describe('serializer-state', () => {
               children: [{ type: 'text', value: 'hello' }],
             },
             { type: 'text', value: ' ' },
+          ],
+        },
+      ],
+    })
+  })
+
+  it('should not corrupt value-based marks during merge', () => {
+    const state = new SerializerState(schema)
+
+    state.openNode('doc')
+    state.openNode('paragraph')
+    // Simulate: inlineCode("Hello") followed by bold > inlineCode("World")
+    state.withMark(inlineCodeMark, 'inlineCode', 'Hello')
+    state.closeMark(inlineCodeMark)
+    state.withMark(boldMark, 'bold')
+    state.withMark(inlineCodeMark, 'inlineCode', 'World')
+    state.closeMark(inlineCodeMark)
+    state.closeMark(boldMark)
+    state.closeNode()
+
+    // The bold wrapper around inlineCode should be preserved,
+    // not restructured by searchType
+    expect(state.top()).toMatchObject({
+      type: 'doc',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'inlineCode',
+              isMark: true,
+              value: 'Hello',
+            },
+            {
+              type: 'bold',
+              isMark: true,
+              children: [
+                {
+                  type: 'inlineCode',
+                  isMark: true,
+                  value: 'World',
+                },
+              ],
+            },
           ],
         },
       ],

--- a/packages/transformer/src/serializer/state.ts
+++ b/packages/transformer/src/serializer/state.ts
@@ -103,7 +103,7 @@ export class SerializerState extends Stack<
     if (child.children?.length !== 1) return child
 
     const searchNode = (node: MarkdownNode): MarkdownNode | null => {
-      if (node.type === type) return node
+      if (node.type === type) return node.value != null ? null : node
 
       if (node.children?.length !== 1) return null
 


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Fixes #1639

When inline code coexists with bold/italic marks on text without whitespace, the serializer produces malformed markdown like `` `InlineCodeWith``Bold``And``Italic``Text` `` instead of `` `InlineCodeWith`**`Bold`**`And`*`Italic`*`Text` ``.

Two issues in the serializer:

1. The `inlineCode` mark runner didn't prevent the text node serializer from running. Since `inlineCode` already passes text as `value` to `withMark`, the text node serializer duplicated the content as a child node. Fixed by returning `true` from the runner.

2. The mark merge logic (`#searchType`) would try to "lift" an `inlineCode` node out of its wrapper mark (e.g. `strong`) to enable merging with an adjacent `inlineCode`. This corrupts the AST because `inlineCode` is a value-based node — remark uses its `value` field, not `children`, so the wrapper mark gets lost. Fixed by skipping the restructuring when the target node has a `value`.

## How did you test this change?

Unit Test