### PR TITLE
feat(preset-commonmark): preserve ordered list custom start number

### DIFF
--- a/e2e/tests/data/ordered-list-custom-start.md
+++ b/e2e/tests/data/ordered-list-custom-start.md
@@ -1,0 +1,3 @@
+5. First
+6. Second
+7. Third

--- a/e2e/tests/input/ordered-list.spec.ts
+++ b/e2e/tests/input/ordered-list.spec.ts
@@ -50,3 +50,19 @@ test('ordered list', async ({ page }) => {
     '1. First item\n2. Second item\n\n   1. Sub list item 1\n   2. Sub list item 2\n3. Third item\n'
   )
 })
+
+test('ordered list with custom start number', async ({ page }) => {
+  const editor = page.locator('.editor')
+  await focusEditor(page)
+  await page.keyboard.type('3. First item')
+  await expect(editor.locator('ol li')).toHaveText('First item')
+  await expect(editor.locator('ol')).toHaveAttribute('start', '3')
+  let markdown = await getMarkdown(page)
+  expect(markdown).toBe('3. First item\n')
+
+  await page.keyboard.press('Enter')
+  await page.keyboard.type('Second item')
+  await expect(editor.locator('ol li:last-child')).toHaveText('Second item')
+  markdown = await getMarkdown(page)
+  expect(markdown).toBe('3. First item\n4. Second item\n')
+})

--- a/e2e/tests/transform/list.spec.ts
+++ b/e2e/tests/transform/list.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-import { focusEditor, loadFixture, setMarkdown } from '../misc'
+import { focusEditor, getMarkdown, loadFixture, setMarkdown } from '../misc'
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/preset-commonmark/')
@@ -30,4 +30,16 @@ test('list', async ({ page }) => {
   expect(await page.locator('.editor>ul:last-child li').count()).toBe(8)
   expect(await page.locator('.editor>ul:last-child ul').count()).toBe(1)
   expect(await page.locator('.editor>ul:last-child ol').count()).toBe(2)
+})
+
+test('ordered list with custom start number', async ({ page }) => {
+  await focusEditor(page)
+  const markdown = await loadFixture('ordered-list-custom-start.md')
+  await setMarkdown(page, markdown)
+
+  await expect(page.locator('.editor>ol')).toHaveAttribute('start', '5')
+  expect(await page.locator('.editor>ol>li').count()).toBe(3)
+
+  const output = await getMarkdown(page)
+  expect(output).toBe(markdown)
 })

--- a/packages/plugins/preset-commonmark/src/node/ordered-list.ts
+++ b/packages/plugins/preset-commonmark/src/node/ordered-list.ts
@@ -53,7 +53,7 @@ export const orderedListSchema = $nodeSchema('ordered_list', (ctx) => ({
     'ol',
     {
       ...ctx.get(orderedListAttr.key)(node),
-      ...(node.attrs.order === 1 ? {} : node.attrs.order),
+      ...(node.attrs.order === 1 ? {} : { start: node.attrs.order }),
       'data-spread': node.attrs.spread,
     },
     0,
@@ -62,7 +62,10 @@ export const orderedListSchema = $nodeSchema('ordered_list', (ctx) => ({
     match: ({ type, ordered }) => type === 'list' && !!ordered,
     runner: (state, node, type) => {
       const spread = node.spread != null ? `${node.spread}` : 'true'
-      state.openNode(type, { spread }).next(node.children).closeNode()
+      state
+        .openNode(type, { spread, order: node.start ?? 1 })
+        .next(node.children)
+        .closeNode()
     },
   },
   toMarkdown: {
@@ -70,7 +73,7 @@ export const orderedListSchema = $nodeSchema('ordered_list', (ctx) => ({
     runner: (state, node) => {
       state.openNode('list', undefined, {
         ordered: true,
-        start: 1,
+        start: node.attrs.order ?? 1,
         spread: node.attrs.spread === 'true',
       })
       state.next(node.content)


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Closes #2277

Support custom start number for ordered lists. Typing `4. test` now creates an ordered list starting at 4 instead of always starting at 1. Also fixed `parseMarkdown` and `toMarkdown` to preserve the start number during round-trips.

## How did you test this change?

Added e2e tests:
- Input rule: verifies typing `3. ` creates a list with `start="3"` and the markdown output preserves the start number
- Markdown round-trip: verifies parsing from markdown sets the correct `start` attribute on `<ol>`, and serializing back produces identical markdown