### PR TITLE
fix(prose): fix Enter key in lists on Chrome Android

### DIFF
--- a/packages/prose/src/toolkit/input-rules/custom-input-rules.ts
+++ b/packages/prose/src/toolkit/input-rules/custom-input-rules.ts
@@ -3,6 +3,7 @@ import type { EditorState, TextSelection, Transaction } from '../../state'
 import type { EditorView } from '../../view'
 
 import { Plugin, PluginKey } from '../../state'
+import { android, chrome } from '../browser'
 
 function run(
   view: EditorView,
@@ -74,6 +75,28 @@ export function customInputRules({ rules }: { rules: InputRule[] }): Plugin {
             const { $cursor } = view.state.selection as TextSelection
             if ($cursor) run(view, $cursor.pos, $cursor.pos, '', rules, plugin)
           })
+          return false
+        },
+        keydown: (view, event) => {
+          // On Chrome Android, prosemirror-view suppresses Enter keydown events
+          // to avoid input corruption during composition. It then relies on DOM
+          // mutation detection to retroactively handle Enter. However, this
+          // fallback fails with custom node views (e.g. list-item-block) whose
+          // wrapper DOM structure prevents the Enter detection heuristics from
+          // recognizing the mutation. We intercept Enter here — before
+          // prosemirror-view's suppression — and manually route it through
+          // handleKeyDown so that keymaps (splitListItem, etc.) work correctly.
+          if (!(android && chrome && (event as KeyboardEvent).key === 'Enter'))
+            return false
+          if (view.composing) return false
+          if (
+            view.someProp('handleKeyDown', (f) =>
+              f(view, event as KeyboardEvent)
+            )
+          ) {
+            event.preventDefault()
+            return true
+          }
           return false
         },
       },


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Fixes #2033

On Chrome Android, `prosemirror-view` suppresses Enter `keydown` events to prevent input corruption during composition (`input.ts:115`). It falls back to DOM mutation detection in `domchange.ts` to retroactively synthesize `handleKeyDown(Enter)` calls. This works fine with standard ProseMirror rendering, but breaks when custom node views (e.g. `listItemBlockView`) wrap content in extra `<div>` elements — the DOM structure prevents the Enter detection heuristics from recognizing the mutation as an Enter press.

The result: pressing Enter in a list item on Android creates an extra empty list item instead of properly splitting.

This PR adds a `handleDOMEvents.keydown` handler in the `customInputRules` plugin. Since `handleDOMEvents` runs before prosemirror-view's internal `editHandlers`, we can intercept the Enter key before it gets suppressed and manually route it through `view.someProp("handleKeyDown")` to invoke all registered keymap handlers (including `splitListItem`). The handler only activates on Chrome Android and skips composition state.

## How did you test this change?

Manually with Android UA.