### PR TITLE
fix(preset-commonmark): ordered list label ignores start attribute

### DIFF
--- a/e2e/tests/input/ordered-list.spec.ts
+++ b/e2e/tests/input/ordered-list.spec.ts
@@ -57,12 +57,17 @@ test('ordered list with custom start number', async ({ page }) => {
   await page.keyboard.type('3. First item')
   await expect(editor.locator('ol li')).toHaveText('First item')
   await expect(editor.locator('ol')).toHaveAttribute('start', '3')
+  await expect(editor.locator('ol li')).toHaveAttribute('data-label', '3.')
   let markdown = await getMarkdown(page)
   expect(markdown).toBe('3. First item\n')
 
   await page.keyboard.press('Enter')
   await page.keyboard.type('Second item')
   await expect(editor.locator('ol li:last-child')).toHaveText('Second item')
+  await expect(editor.locator('ol li:last-child')).toHaveAttribute(
+    'data-label',
+    '4.'
+  )
   markdown = await getMarkdown(page)
   expect(markdown).toBe('3. First item\n4. Second item\n')
 })

--- a/packages/plugins/preset-commonmark/src/plugin/sync-list-order-plugin.ts
+++ b/packages/plugins/preset-commonmark/src/plugin/sync-list-order-plugin.ts
@@ -31,10 +31,11 @@ export const syncListOrderPlugin = $prose((ctx) => {
 
     const handleNodeItem = (
       attrs: Record<string, any>,
-      index: number
+      index: number,
+      order: number = 1
     ): boolean => {
       let changed = false
-      const expectedLabel = `${index + 1}.`
+      const expectedLabel = `${index + order}.`
       if (attrs.label !== expectedLabel) {
         attrs.label = expectedLabel
         changed = true
@@ -85,7 +86,8 @@ export const syncListOrderPlugin = $prose((ctx) => {
           }
 
           const base = parent?.maybeChild(0)
-          if (base) changed = handleNodeItem(attrs, index)
+          if (base)
+            changed = handleNodeItem(attrs, index, parent?.attrs.order ?? 1)
 
           if (changed) {
             tr = tr.setNodeMarkup(pos, undefined, attrs)


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

When inputting an ordered list with a custom start number (e.g. `3. abc`), the `syncListOrderPlugin` always calculates list item labels starting from 1, because `handleNodeItem` uses `index + 1` without considering the parent ordered list's `order` attribute. This causes the editor to render `1. abc` even though the markdown output is correct (`3. abc`).

Fixed by passing the parent's `order` attribute into the label calculation.

## How did you test this change?

Added `data-label` assertions to the existing e2e test `ordered list with custom start number` to verify that the rendered labels match the expected start number. All e2e tests pass.