### PR TITLE
feat: per-block diff via LCS matching

### DIFF
--- a/packages/components/src/diff/__tests__/diff-utils.spec.ts
+++ b/packages/components/src/diff/__tests__/diff-utils.spec.ts
@@ -1,0 +1,332 @@
+import type { Change } from '@milkdown/prose/changeset'
+
+import { Schema } from '@milkdown/prose/model'
+import { describe, expect, it } from 'vitest'
+
+import type { MergedChange } from '../merge-changes'
+
+import {
+  hasBlockContent,
+  isBlockSpanning,
+  trailingEmptyParagraphStart,
+} from '../doc-utils'
+import {
+  anchorTrailingInsertsBeforeEmptyParagraph,
+  mergeBlockChanges,
+} from '../merge-changes'
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: { group: 'block', content: 'inline*', toDOM: () => ['p', 0] },
+    text: { group: 'inline' },
+    bullet_list: {
+      group: 'block',
+      content: 'list_item+',
+      toDOM: () => ['ul', 0],
+    },
+    list_item: {
+      content: 'paragraph+',
+      attrs: { checked: { default: false } },
+      toDOM: () => ['li', 0],
+    },
+    table: {
+      group: 'block',
+      content: 'table_row+',
+      toDOM: () => ['table', ['tbody', 0]],
+    },
+    table_row: {
+      content: 'table_cell+',
+      toDOM: () => ['tr', 0],
+    },
+    table_cell: {
+      content: 'inline*',
+      attrs: { header: { default: false } },
+      toDOM: (node) => [node.attrs.header ? 'th' : 'td', 0],
+    },
+  },
+})
+
+const t = (s: string) => schema.text(s)
+const p = (...c: any[]) => schema.node('paragraph', null, c)
+const doc = (...c: any[]) => schema.node('doc', null, c)
+const li = (attrs: any, ...c: any[]) => schema.node('list_item', attrs, c)
+const ul = (...c: any[]) => schema.node('bullet_list', null, c)
+const td = (...c: any[]) => schema.node('table_cell', { header: false }, c)
+const th = (...c: any[]) => schema.node('table_cell', { header: true }, c)
+const row = (...c: any[]) => schema.node('table_row', null, c)
+const table = (...r: any[]) => schema.node('table', null, r)
+
+const chg = (fromA: number, toA: number, fromB: number, toB: number): Change =>
+  ({ fromA, toA, fromB, toB, deleted: [], inserted: [] }) as unknown as Change
+
+describe('hasBlockContent', () => {
+  it('returns false for a 1-char edit inside a list item paragraph', () => {
+    // Reproduces the task-list bug: a tiny inline edit inside a list item
+    // paragraph used to return true because doc.slice() grabbed the
+    // surrounding bullet_list/list_item wrappers as "block content".
+    const d = doc(
+      ul(
+        li({ checked: false }, p(t('hello'))),
+        li({ checked: false }, p(t('world')))
+      )
+    )
+    // Inside "hello" — depth 3 (doc > bullet_list > list_item > paragraph).
+    // Position 3 is inside the first paragraph.
+    expect(hasBlockContent(d, 3, 4)).toBe(false)
+  })
+
+  it('returns false for a 1-char attr-token change at a list_item boundary', () => {
+    // Reproduces the exact runtime case: replacing the opening token of a
+    // list_item (e.g. because its `checked` attribute flipped). The slice
+    // contains an open-token list_item wrapper which should NOT count as
+    // block content.
+    const d = doc(
+      ul(li({ checked: false }, p(t('a'))), li({ checked: false }, p(t('b'))))
+    )
+    // Walk the doc to find a position that sits at the bullet_list depth
+    // just before the second list_item — resolve(pos).depth === 1 means we
+    // are at the list_item boundary inside the bullet_list.
+    let boundaryPos = -1
+    for (let i = 1; i < d.content.size; i++) {
+      const $p = d.resolve(i)
+      if ($p.depth !== 1) continue
+      if ($p.parent.type.name !== 'bullet_list') continue
+      if ($p.index(1) !== 1) continue
+      boundaryPos = i
+      break
+    }
+    expect(boundaryPos).toBeGreaterThan(0)
+    expect(hasBlockContent(d, boundaryPos, boundaryPos + 1)).toBe(false)
+  })
+
+  it('returns true when a full top-level block is enclosed', () => {
+    const d = doc(p(t('first')), p(t('second')))
+    // Whole doc range must include a real block.
+    expect(hasBlockContent(d, 0, d.content.size)).toBe(true)
+  })
+
+  it('returns true when a nested block (paragraph inside list_item) is enclosed', () => {
+    const d = doc(
+      ul(
+        li({ checked: false }, p(t('first'))),
+        li({ checked: false }, p(t('second')))
+      )
+    )
+    // Range that covers the entire first list_item's content. This
+    // includes a full paragraph as nested block content.
+    expect(hasBlockContent(d, 0, d.content.size)).toBe(true)
+  })
+
+  it('returns false for a range inside a single textblock', () => {
+    const d = doc(p(t('hello world')))
+    expect(hasBlockContent(d, 2, 5)).toBe(false)
+  })
+
+  it('isBlockSpanning agrees on the list-item boundary case', () => {
+    const d = doc(
+      ul(li({ checked: false }, p(t('a'))), li({ checked: false }, p(t('b'))))
+    )
+    // All positions here are inside the same top-level bullet_list, so
+    // no top-level block crossing.
+    expect(isBlockSpanning(d, 3, 4)).toBe(false)
+  })
+})
+
+describe('mergeBlockChanges — pure inserts/deletes at custom block boundary', () => {
+  const customBlockTypes = new Set(['table'])
+
+  // Build a doc with: paragraph "hello", table, paragraph "after"
+  // Position layout:
+  //   paragraph "hello": [0, 7]   (open=0, text=1..6, close=7)
+  //   table:             [7, ...]
+  const oldDoc = doc(p(t('hello')), table(row(th(t('h1'))), row(td(t('v1')))))
+  // newDoc is the same but also has a paragraph appended at the end.
+  const newDoc = doc(
+    p(t('hello')),
+    table(row(th(t('h1'))), row(td(t('v1')))),
+    p(t('tail'))
+  )
+
+  const tableEndA = oldDoc.content.size
+  const tableEndB = oldDoc.content.size // table ends at same position in newDoc
+  const newDocSize = newDoc.content.size
+
+  it('does not expand a pure insert right after a table into the table', () => {
+    // Pure insertion at the END of the old doc (right after the table).
+    // fromA === toA === tableEndA.  The inserted content in newDoc starts
+    // at tableEndB and extends to newDocSize (the "tail" paragraph).
+    const change = chg(tableEndA, tableEndA, tableEndB, newDocSize)
+    const merged = mergeBlockChanges([change], oldDoc, newDoc, customBlockTypes)
+    expect(merged).toHaveLength(1)
+    // The change should NOT have been promoted to a custom-block merge,
+    // because the insertion is merely adjacent to the table, not inside it.
+    expect(merged[0]!.isCustomBlock).toBe(false)
+    // And the range must remain the original pure insertion — no expansion
+    // backwards over the table.
+    expect(merged[0]!.fromA).toBe(tableEndA)
+    expect(merged[0]!.toA).toBe(tableEndA)
+    expect(merged[0]!.fromB).toBe(tableEndB)
+    expect(merged[0]!.toB).toBe(newDocSize)
+  })
+
+  it('does not expand a pure delete right before a table into the table', () => {
+    // Pure deletion that removes content ending at the table's start,
+    // with fromB === toB at the table's start in newDoc.
+    // Build: newDoc has the same table at a later offset (after the
+    // "hello" paragraph was inserted). Simulate a pure deletion where
+    // fromB === toB sits exactly at the table's start in newDoc.
+    const oldD = doc(p(t('xxx')), table(row(th(t('h1'))), row(td(t('v1')))))
+    const newD = doc(table(row(th(t('h1'))), row(td(t('v1')))))
+    // Deletion of the leading paragraph: fromA=0, toA=paragraph size,
+    // fromB=toB=0 in newD (which is the start of the table).
+    const paragraphEnd = oldD.child(0).nodeSize
+    const change = chg(0, paragraphEnd, 0, 0)
+    const merged = mergeBlockChanges([change], oldD, newD, customBlockTypes)
+    expect(merged).toHaveLength(1)
+    expect(merged[0]!.isCustomBlock).toBe(false)
+    expect(merged[0]!.fromA).toBe(0)
+    expect(merged[0]!.toA).toBe(paragraphEnd)
+    expect(merged[0]!.fromB).toBe(0)
+    expect(merged[0]!.toB).toBe(0)
+  })
+
+  it('still merges changes that genuinely sit inside a table', () => {
+    // A non-pure change whose range actually covers content inside the
+    // table should still be promoted to an isCustomBlock merged change.
+    // Replace the whole table body: fromA covers the entire table, same
+    // in newDoc.
+    const oldD = doc(table(row(td(t('a'))), row(td(t('b')))))
+    const newD = doc(table(row(td(t('x'))), row(td(t('y')))))
+    const change = chg(0, oldD.content.size, 0, newD.content.size)
+    const merged = mergeBlockChanges([change], oldD, newD, customBlockTypes)
+    expect(merged).toHaveLength(1)
+    expect(merged[0]!.isCustomBlock).toBe(true)
+  })
+
+  it('coalesces two changes that expand into the same custom block', () => {
+    // Two separate non-empty changes, each overlapping the table on a
+    // different side, should collapse into a single merged change —
+    // otherwise the decoration plugin renders the new table twice.
+    const oldD = doc(
+      p(t('head')),
+      table(row(td(t('a'))), row(td(t('b')))),
+      p(t('tail'))
+    )
+    const newD = doc(
+      p(t('HEAD')),
+      table(row(td(t('x'))), row(td(t('y')))),
+      p(t('TAIL'))
+    )
+    // Change 1: start of doc into the first table cell.
+    const c1 = chg(1, 8, 1, 8)
+    // Change 2: last cell of table into the tail paragraph.
+    const c2 = chg(
+      oldD.content.size - 7,
+      oldD.content.size - 1,
+      newD.content.size - 7,
+      newD.content.size - 1
+    )
+    const merged = mergeBlockChanges([c1, c2], oldD, newD, customBlockTypes)
+    expect(merged).toHaveLength(1)
+    expect(merged[0]!.isCustomBlock).toBe(true)
+    // Union range spans both original changes in both docs.
+    expect(merged[0]!.fromA).toBeLessThanOrEqual(1)
+    expect(merged[0]!.toA).toBeGreaterThanOrEqual(oldD.content.size - 1)
+    expect(merged[0]!.fromB).toBeLessThanOrEqual(1)
+    expect(merged[0]!.toB).toBeGreaterThanOrEqual(newD.content.size - 1)
+  })
+})
+
+describe('trailingEmptyParagraphStart', () => {
+  it('returns doc.content.size when there is no trailing empty paragraph', () => {
+    const d = doc(p(t('hello')), p(t('world')))
+    expect(trailingEmptyParagraphStart(d)).toBe(d.content.size)
+  })
+
+  it('returns the start of a single trailing empty paragraph', () => {
+    const d = doc(p(t('hello')), p())
+    const emptySize = d.child(1).nodeSize
+    expect(trailingEmptyParagraphStart(d)).toBe(d.content.size - emptySize)
+  })
+
+  it('returns the start of multiple trailing empty paragraphs', () => {
+    const d = doc(p(t('hello')), p(), p(), p())
+    const trailingSize =
+      d.child(1).nodeSize + d.child(2).nodeSize + d.child(3).nodeSize
+    expect(trailingEmptyParagraphStart(d)).toBe(d.content.size - trailingSize)
+  })
+
+  it('returns doc.content.size when last block is a non-empty paragraph', () => {
+    const d = doc(p(), p(t('hello')))
+    expect(trailingEmptyParagraphStart(d)).toBe(d.content.size)
+  })
+
+  it('stops at the first non-paragraph block walking backwards', () => {
+    // Empty paragraph after a table is still trailing, but an empty
+    // paragraph before a table is not — walking backwards must stop at
+    // the table.
+    const tableNode = table(row(td(t('a'))))
+    const d = doc(p(), tableNode, p())
+    const lastEmptySize = d.child(2).nodeSize
+    expect(trailingEmptyParagraphStart(d)).toBe(d.content.size - lastEmptySize)
+  })
+})
+
+describe('anchorTrailingInsertsBeforeEmptyParagraph', () => {
+  const mc = (
+    fromA: number,
+    toA: number,
+    fromB: number,
+    toB: number
+  ): MergedChange => ({ fromA, toA, fromB, toB, isCustomBlock: false })
+
+  it('remaps a pure insert at doc end to before the trailing empty paragraph', () => {
+    // Reproduces the New Section regression: an insertion at the doc end
+    // must anchor *before* the trailing empty paragraph, otherwise the
+    // accept command splices the new content after the empty paragraph
+    // and the next recompute renders it as an orphaned block deletion.
+    const d = doc(p(t('hello')), p())
+    const trailingStart = trailingEmptyParagraphStart(d)
+    const changes: MergedChange[] = [mc(d.content.size, d.content.size, 0, 10)]
+    anchorTrailingInsertsBeforeEmptyParagraph(changes, d)
+    expect(changes[0]!.fromA).toBe(trailingStart)
+    expect(changes[0]!.toA).toBe(trailingStart)
+  })
+
+  it('leaves inserts before the trailing empty paragraph alone', () => {
+    const d = doc(p(t('hello')), p())
+    const changes: MergedChange[] = [mc(1, 1, 0, 10)]
+    anchorTrailingInsertsBeforeEmptyParagraph(changes, d)
+    expect(changes[0]!.fromA).toBe(1)
+    expect(changes[0]!.toA).toBe(1)
+  })
+
+  it('does not touch non-insert changes (deletions or replacements)', () => {
+    const d = doc(p(t('hello')), p())
+    const original = mc(d.content.size - 1, d.content.size, 0, 0)
+    const changes: MergedChange[] = [{ ...original }]
+    anchorTrailingInsertsBeforeEmptyParagraph(changes, d)
+    expect(changes[0]).toEqual(original)
+  })
+
+  it('is a no-op when the doc has no trailing empty paragraph', () => {
+    const d = doc(p(t('hello')), p(t('world')))
+    const original = mc(d.content.size, d.content.size, 0, 10)
+    const changes: MergedChange[] = [{ ...original }]
+    anchorTrailingInsertsBeforeEmptyParagraph(changes, d)
+    expect(changes[0]).toEqual(original)
+  })
+
+  it('remaps multiple inserts in the trailing empty region', () => {
+    const d = doc(p(t('hello')), p())
+    const trailingStart = trailingEmptyParagraphStart(d)
+    const changes: MergedChange[] = [
+      mc(d.content.size, d.content.size, 0, 5),
+      mc(d.content.size, d.content.size, 5, 20),
+    ]
+    anchorTrailingInsertsBeforeEmptyParagraph(changes, d)
+    expect(changes[0]!.fromA).toBe(trailingStart)
+    expect(changes[1]!.fromA).toBe(trailingStart)
+  })
+})

--- a/packages/components/src/diff/__tests__/diff-utils.spec.ts
+++ b/packages/components/src/diff/__tests__/diff-utils.spec.ts
@@ -204,6 +204,55 @@ describe('mergeBlockChanges — pure inserts/deletes at custom block boundary', 
     expect(merged[0]!.isCustomBlock).toBe(true)
   })
 
+  it('produces no overlapping custom-block entries across multiple tables', () => {
+    // Invariant check: when multiple seeds touch different tables, the
+    // merged output must never contain two custom-block entries whose
+    // ranges overlap in either doc. Coalescing walks all existing entries
+    // (not just the first) to guarantee this.
+    const oldD = doc(
+      table(row(td(t('a')))),
+      p(t('mid')),
+      table(row(td(t('b'))))
+    )
+    const newD = doc(
+      table(row(td(t('A')))),
+      p(t('MID')),
+      table(row(td(t('B'))))
+    )
+    const t1End = oldD.child(0).nodeSize
+    const midSize = oldD.child(1).nodeSize
+    const t2Start = t1End + midSize
+    const t2End = t2Start + oldD.child(2).nodeSize
+    // Two seeds inside the tables emit independent custom-block merges.
+    const seedInT1 = chg(2, 3, 2, 3)
+    const seedInT2 = chg(t2Start + 2, t2Start + 3, t2Start + 2, t2Start + 3)
+    // A third seed whose range pokes into both tables (last cell of table 1
+    // through first cell of table 2). Both endpoints resolve inside a table
+    // via their ancestor chain, so mergeBlockChanges expands it.
+    const seedAcross = chg(t1End - 1, t2Start + 1, t1End - 1, t2Start + 1)
+    const merged = mergeBlockChanges(
+      [seedInT1, seedInT2, seedAcross],
+      oldD,
+      newD,
+      customBlockTypes
+    )
+    // All three seeds should collapse into a single custom-block entry.
+    const customEntries = merged.filter((m) => m.isCustomBlock)
+    expect(customEntries).toHaveLength(1)
+    expect(customEntries[0]!.fromA).toBeLessThanOrEqual(0)
+    expect(customEntries[0]!.toA).toBeGreaterThanOrEqual(t2End)
+    // And no two entries should overlap in either doc.
+    for (let i = 0; i < merged.length; i++) {
+      for (let j = i + 1; j < merged.length; j++) {
+        const a = merged[i]!
+        const b = merged[j]!
+        const overlapA = a.fromA < b.toA && a.toA > b.fromA
+        const overlapB = a.fromB < b.toB && a.toB > b.fromB
+        expect(overlapA || overlapB).toBe(false)
+      }
+    }
+  })
+
   it('coalesces two changes that expand into the same custom block', () => {
     // Two separate non-empty changes, each overlapping the table on a
     // different side, should collapse into a single merged change —

--- a/packages/components/src/diff/diff-decoration-plugin.ts
+++ b/packages/components/src/diff/diff-decoration-plugin.ts
@@ -21,13 +21,17 @@ import { withMeta } from '../__internal__/meta'
 import { diffComponentConfig } from './config'
 import {
   addBlockDeletionDecorations,
-  coversOnlyTrailingEmptyParagraphs,
   collectTopLevelNodes,
+  coversOnlyTrailingEmptyParagraphs,
   hasBlockContent,
   isBlockSpanning,
   snapToBlockBoundary,
 } from './doc-utils'
-import { mergeBlockChanges, splitCrossBoundaryChange } from './merge-changes'
+import {
+  anchorTrailingInsertsBeforeEmptyParagraph,
+  mergeBlockChanges,
+  splitCrossBoundaryChange,
+} from './merge-changes'
 
 const diffDecorationKey = new PluginKey<DecorationSet>(
   'MILKDOWN_DIFF_DECORATION'
@@ -180,6 +184,7 @@ function buildDecorations(
     diffState.newDoc,
     customBlockTypes
   )
+  anchorTrailingInsertsBeforeEmptyParagraph(mergedChanges, doc)
 
   for (let i = 0; i < mergedChanges.length; i++) {
     const change = mergedChanges[i]!

--- a/packages/components/src/diff/doc-utils.ts
+++ b/packages/components/src/diff/doc-utils.ts
@@ -19,15 +19,36 @@ export function isBlockSpanning(doc: Node, from: number, to: number): boolean {
   return fromIndex !== toIndex
 }
 
-/// Check if a slice from a doc contains block-level content.
+/// Check if a range in a doc contains any fully-enclosed block node.
+/// Returns false for purely-inline ranges and for 1-char attribute-token
+/// edits that only touch a block node's open/close boundary without
+/// enclosing any real block content.
 export function hasBlockContent(doc: Node, from: number, to: number): boolean {
   if (from >= to) return false
 
-  const slice = doc.slice(from, to)
-  for (let i = 0; i < slice.content.childCount; i++) {
-    if (slice.content.child(i).isBlock) return true
-  }
-  return false
+  // Fast path: if both endpoints share the same textblock parent,
+  // the range is purely inline — no block crossings.
+  const $from = doc.resolve(from)
+  const $to = doc.resolve(to)
+  if ($from.sameParent($to) && $from.parent.isTextblock) return false
+
+  // Walk all descendants and return true only if we find a block node
+  // fully enclosed by [from, to]. Wrapper nodes that partially overlap
+  // (e.g. a bullet_list that contains the range) do NOT count — those
+  // get picked up by isBlockSpanning for real cross-block edits.
+  let found = false
+  doc.nodesBetween(from, to, (node, pos) => {
+    if (found) return false
+    if (!node.isBlock) return true
+    const nodeEnd = pos + node.nodeSize
+    if (pos >= from && nodeEnd <= to) {
+      found = true
+      return false
+    }
+    // Node only partially overlaps — descend into its children.
+    return true
+  })
+  return found
 }
 
 /// Check if a range in a doc covers only trailing empty paragraphs at the end.
@@ -47,6 +68,21 @@ export function coversOnlyTrailingEmptyParagraphs(
     if (child.type.name !== 'paragraph' || child.content.size > 0) return false
   }
   return true
+}
+
+/// Return the top-level position where the doc's run of trailing empty
+/// paragraphs begins. If the doc has no trailing empty paragraph, returns
+/// `doc.content.size`. Crepe-like editors always keep an empty paragraph
+/// at the end — inserts that target the doc end should anchor here so
+/// the empty paragraph stays in its trailing spot.
+export function trailingEmptyParagraphStart(doc: Node): number {
+  let start = doc.content.size
+  for (let i = doc.childCount - 1; i >= 0; i--) {
+    const child = doc.child(i)
+    if (child.type.name !== 'paragraph' || child.content.size > 0) break
+    start -= child.nodeSize
+  }
+  return start
 }
 
 /// For block-level widgets, find a position between blocks rather than
@@ -157,6 +193,25 @@ export function getTopLevelBlockRange(
   return null
 }
 
+/// Check only the ancestor chain of `pos` for a custom block.
+/// Unlike `getCustomBlockAt`, this does NOT consider nodeBefore/nodeAfter —
+/// it returns null for positions that merely sit at the boundary between
+/// top-level blocks. Use this for empty ranges (pure inserts/deletes) where
+/// a boundary anchor shouldn't be treated as "touching" its neighbours.
+export function getCustomBlockAncestor(
+  doc: Node,
+  pos: number,
+  customBlockTypes: Set<string>
+): string | null {
+  if (pos < 0 || pos > doc.content.size) return null
+  const $pos = doc.resolve(Math.min(pos, doc.content.size))
+  for (let d = $pos.depth; d >= 0; d--) {
+    const name = $pos.node(d).type.name
+    if (customBlockTypes.has(name)) return name
+  }
+  return null
+}
+
 /// Check if a position falls inside or at a custom block node in the given document.
 /// Returns the node type name if found, or null.
 ///
@@ -170,30 +225,18 @@ export function getCustomBlockAt(
   customBlockTypes: Set<string>,
   endBoundary = false
 ): string | null {
-  if (pos < 0 || pos > doc.content.size) return null
+  const ancestor = getCustomBlockAncestor(doc, pos, customBlockTypes)
+  if (ancestor) return ancestor
 
-  const $pos = doc.resolve(Math.min(pos, doc.content.size))
-
-  // Check ancestor nodes (for positions inside tables, code blocks, etc.)
-  for (let d = $pos.depth; d >= 0; d--) {
-    const name = $pos.node(d).type.name
-    if (customBlockTypes.has(name)) return name
-  }
-
-  // For range starts and point positions, check the node immediately after
-  // the position (atom/leaf nodes like image-block are touched by the start).
-  // For exclusive range ends, check the node immediately before instead —
-  // `nodeAfter` is past the range end and not actually touched.
-  if (endBoundary) {
-    const nodeBefore = $pos.nodeBefore
-    if (nodeBefore && customBlockTypes.has(nodeBefore.type.name))
-      return nodeBefore.type.name
-  } else {
-    const nodeAfter = $pos.nodeAfter
-    if (nodeAfter && customBlockTypes.has(nodeAfter.type.name))
-      return nodeAfter.type.name
-  }
-
+  // Not inside a custom block's ancestor chain — check the sibling on the
+  // touched side. For range starts and point positions this is nodeAfter
+  // (atom/leaf nodes like image-block are touched by the start). For
+  // exclusive range ends we look at nodeBefore instead — nodeAfter is past
+  // the range end and not actually touched.
+  const $pos = doc.resolve(Math.min(Math.max(pos, 0), doc.content.size))
+  const sibling = endBoundary ? $pos.nodeBefore : $pos.nodeAfter
+  if (sibling && customBlockTypes.has(sibling.type.name))
+    return sibling.type.name
   return null
 }
 

--- a/packages/components/src/diff/merge-changes.ts
+++ b/packages/components/src/diff/merge-changes.ts
@@ -1,7 +1,39 @@
 import type { Change } from '@milkdown/prose/changeset'
 import type { Node } from '@milkdown/prose/model'
 
-import { getCustomBlockAt, getTopLevelBlockRange } from './doc-utils'
+import {
+  getCustomBlockAncestor,
+  getCustomBlockAt,
+  getTopLevelBlockRange,
+  trailingEmptyParagraphStart,
+} from './doc-utils'
+
+/// Half-open interval overlap: do [a1, a2) and [b1, b2) share any position?
+function overlaps(a1: number, a2: number, b1: number, b2: number): boolean {
+  return a1 < b2 && a2 > b1
+}
+
+/// Does a range [from, to) in `doc` touch a custom block?
+///
+/// Non-empty ranges use the full boundary check — a position at the edge
+/// of a custom block counts as touching. Empty ranges (from === to) only
+/// count if the anchor is *inside* a custom block's ancestor chain; a
+/// point sitting between two top-level nodes isn't touching either
+/// neighbour and shouldn't trigger custom-block merging.
+function touchesCustomBlockRange(
+  doc: Node,
+  from: number,
+  to: number,
+  customBlockTypes: Set<string>
+): boolean {
+  if (from === to) {
+    return getCustomBlockAncestor(doc, from, customBlockTypes) != null
+  }
+  return (
+    getCustomBlockAt(doc, from, customBlockTypes) != null ||
+    getCustomBlockAt(doc, to, customBlockTypes, true) != null
+  )
+}
 
 export interface MergedChange {
   fromA: number
@@ -100,10 +132,8 @@ function changeTouchesCustomBlock(
   customBlockTypes: Set<string>
 ): boolean {
   return (
-    getCustomBlockAt(doc, change.fromA, customBlockTypes) != null ||
-    getCustomBlockAt(doc, change.toA, customBlockTypes, true) != null ||
-    getCustomBlockAt(newDoc, change.fromB, customBlockTypes) != null ||
-    getCustomBlockAt(newDoc, change.toB, customBlockTypes, true) != null
+    touchesCustomBlockRange(doc, change.fromA, change.toA, customBlockTypes) ||
+    touchesCustomBlockRange(newDoc, change.fromB, change.toB, customBlockTypes)
   )
 }
 
@@ -135,32 +165,25 @@ export function mergeBlockChanges(
       continue
     }
 
-    // Only expand each side when that side actually touches a custom block.
-    // Choose the endpoint based on which one actually touches the custom
-    // block — otherwise getTopLevelBlockRange would return an unrelated
-    // adjacent node.
-    const aFromTouches =
-      getCustomBlockAt(doc, change.fromA, customBlockTypes) != null
-    const aToTouches =
-      getCustomBlockAt(doc, change.toA, customBlockTypes, true) != null
-    const bFromTouches =
-      getCustomBlockAt(newDoc, change.fromB, customBlockTypes) != null
-    const bToTouches =
-      getCustomBlockAt(newDoc, change.toB, customBlockTypes, true) != null
-    const blockRangeA = aFromTouches
-      ? getTopLevelBlockRange(doc, change.fromA)
-      : aToTouches
-        ? getTopLevelBlockRange(doc, change.toA, true)
-        : null
-    const blockRangeB = bFromTouches
-      ? getTopLevelBlockRange(newDoc, change.fromB)
-      : bToTouches
-        ? getTopLevelBlockRange(newDoc, change.toB, true)
-        : null
+    // Expand each side to the enclosing top-level block when that side
+    // actually touches a custom block. For pure inserts/deletes, only the
+    // ancestor check counts — a boundary anchor next to a block doesn't
+    // drag the block into the merge.
+    const blockRangeA = expandToCustomBlockRange(
+      doc,
+      change.fromA,
+      change.toA,
+      customBlockTypes
+    )
+    const blockRangeB = expandToCustomBlockRange(
+      newDoc,
+      change.fromB,
+      change.toB,
+      customBlockTypes
+    )
 
-    // Collect all changes that overlap with this block.
-    // Use the union of the block range and the original change range
-    // so we don't truncate changes that extend beyond the block.
+    // Union of the block range and the original change range so we don't
+    // truncate changes that extend beyond the block.
     const merged: MergedChange = {
       fromA: Math.min(blockRangeA?.from ?? change.fromA, change.fromA),
       toA: Math.max(blockRangeA?.to ?? change.toA, change.toA),
@@ -170,33 +193,90 @@ export function mergeBlockChanges(
     }
     consumed.add(i)
 
+    // Absorb any later changes that overlap the block range in either doc.
     for (let j = i + 1; j < pending.length; j++) {
       if (consumed.has(j)) continue
-
       const other = pending[j]!
-      // Check if the other change overlaps with the block range in either doc
-      // Use exclusive end boundary to avoid absorbing changes that start right after the block
       const overlapA =
         blockRangeA &&
-        other.fromA < blockRangeA.to &&
-        other.toA > blockRangeA.from
+        overlaps(other.fromA, other.toA, blockRangeA.from, blockRangeA.to)
       const overlapB =
         blockRangeB &&
-        other.fromB < blockRangeB.to &&
-        other.toB > blockRangeB.from
-
-      if (overlapA || overlapB) {
-        consumed.add(j)
-        // Expand the merged range to include this change
-        merged.fromA = Math.min(merged.fromA, other.fromA)
-        merged.toA = Math.max(merged.toA, other.toA)
-        merged.fromB = Math.min(merged.fromB, other.fromB)
-        merged.toB = Math.max(merged.toB, other.toB)
-      }
+        overlaps(other.fromB, other.toB, blockRangeB.from, blockRangeB.to)
+      if (!overlapA && !overlapB) continue
+      consumed.add(j)
+      merged.fromA = Math.min(merged.fromA, other.fromA)
+      merged.toA = Math.max(merged.toA, other.toA)
+      merged.fromB = Math.min(merged.fromB, other.fromB)
+      merged.toB = Math.max(merged.toB, other.toB)
     }
 
-    result.push(merged)
+    // Coalesce with an already-emitted merged change whose custom-block
+    // range overlaps this one. Two seed changes can independently expand
+    // to cover the same custom block (e.g. a deletion just before a table
+    // and an insertion just after it), which would otherwise render the
+    // same block as a widget twice.
+    const existing = result.find(
+      (prev) =>
+        prev.isCustomBlock &&
+        (overlaps(merged.fromA, merged.toA, prev.fromA, prev.toA) ||
+          overlaps(merged.fromB, merged.toB, prev.fromB, prev.toB))
+    )
+    if (existing) {
+      existing.fromA = Math.min(existing.fromA, merged.fromA)
+      existing.toA = Math.max(existing.toA, merged.toA)
+      existing.fromB = Math.min(existing.fromB, merged.fromB)
+      existing.toB = Math.max(existing.toB, merged.toB)
+    } else {
+      result.push(merged)
+    }
   }
 
   return result
+}
+
+/// Remap pure inserts that sit at or past the doc's run of trailing empty
+/// paragraphs so they anchor *before* the empty paragraph instead of after.
+///
+/// Editors like Crepe always keep an empty paragraph at the doc end. A pure
+/// insert produced at `fromA === doc.content.size` would otherwise be spliced
+/// after the trailing empty paragraph, pushing it out of its trailing slot.
+/// The next diff recompute would then see the empty paragraph as middle-of-doc
+/// content that needs to be deleted, flashing an empty-looking removal widget.
+export function anchorTrailingInsertsBeforeEmptyParagraph(
+  changes: MergedChange[],
+  doc: Node
+): void {
+  const trailingStart = trailingEmptyParagraphStart(doc)
+  if (trailingStart === doc.content.size) return
+  for (const change of changes) {
+    const isPureInsert =
+      change.fromA === change.toA && change.fromB < change.toB
+    if (isPureInsert && change.fromA >= trailingStart) {
+      change.fromA = trailingStart
+      change.toA = trailingStart
+    }
+  }
+}
+
+/// Pick the top-level block range enclosing a custom block touched by
+/// [from, to). Returns null if neither endpoint actually touches a custom
+/// block (see `touchesCustomBlockRange` for the touch rules).
+function expandToCustomBlockRange(
+  doc: Node,
+  from: number,
+  to: number,
+  customBlockTypes: Set<string>
+): { from: number; to: number } | null {
+  if (from === to) {
+    if (getCustomBlockAncestor(doc, from, customBlockTypes) == null) return null
+    return getTopLevelBlockRange(doc, from)
+  }
+  if (getCustomBlockAt(doc, from, customBlockTypes) != null) {
+    return getTopLevelBlockRange(doc, from)
+  }
+  if (getCustomBlockAt(doc, to, customBlockTypes, true) != null) {
+    return getTopLevelBlockRange(doc, to, true)
+  }
+  return null
 }

--- a/packages/components/src/diff/merge-changes.ts
+++ b/packages/components/src/diff/merge-changes.ts
@@ -216,20 +216,27 @@ export function mergeBlockChanges(
     // to cover the same custom block (e.g. a deletion just before a table
     // and an insertion just after it), which would otherwise render the
     // same block as a widget twice.
-    const existing = result.find(
-      (prev) =>
-        prev.isCustomBlock &&
-        (overlaps(merged.fromA, merged.toA, prev.fromA, prev.toA) ||
-          overlaps(merged.fromB, merged.toB, prev.fromB, prev.toB))
-    )
-    if (existing) {
-      existing.fromA = Math.min(existing.fromA, merged.fromA)
-      existing.toA = Math.max(existing.toA, merged.toA)
-      existing.fromB = Math.min(existing.fromB, merged.fromB)
-      existing.toB = Math.max(existing.toB, merged.toB)
-    } else {
-      result.push(merged)
+    // Coalesce with every already-emitted custom-block merged change whose
+    // range overlaps this one, not just the first. A seed could straddle
+    // two previously-emitted custom blocks, and merging into only the first
+    // would leave overlapping duplicates in the result.
+    const absorbedIndexes: number[] = []
+    for (let k = 0; k < result.length; k++) {
+      const prev = result[k]!
+      if (!prev.isCustomBlock) continue
+      const touchesA = overlaps(merged.fromA, merged.toA, prev.fromA, prev.toA)
+      const touchesB = overlaps(merged.fromB, merged.toB, prev.fromB, prev.toB)
+      if (!touchesA && !touchesB) continue
+      merged.fromA = Math.min(merged.fromA, prev.fromA)
+      merged.toA = Math.max(merged.toA, prev.toA)
+      merged.fromB = Math.min(merged.fromB, prev.fromB)
+      merged.toB = Math.max(merged.toB, prev.toB)
+      absorbedIndexes.push(k)
     }
+    for (let k = absorbedIndexes.length - 1; k >= 0; k--) {
+      result.splice(absorbedIndexes[k]!, 1)
+    }
+    result.push(merged)
   }
 
   return result

--- a/packages/plugins/plugin-diff/src/__test__/diff-compute.spec.ts
+++ b/packages/plugins/plugin-diff/src/__test__/diff-compute.spec.ts
@@ -648,3 +648,189 @@ describe('computeDocDiff - ignoreAttrs', () => {
     expect(changes.length).toBeGreaterThan(0)
   })
 })
+
+describe('computeDocDiff - per-block matching', () => {
+  it('independent paragraph edits produce separate non-overlapping changes', () => {
+    const oldDoc = doc(p(text('AAA')), p(text('BBB')), p(text('CCC')))
+    const newDoc = doc(p(text('XXX')), p(text('BBB')), p(text('ZZZ')))
+
+    const changes = computeDocDiff(oldDoc, newDoc)
+    expect(changes.length).toBeGreaterThanOrEqual(2)
+
+    // Sorted and non-overlapping
+    for (let i = 1; i < changes.length; i++) {
+      expect(changes[i]!.fromA).toBeGreaterThanOrEqual(changes[i - 1]!.toA)
+      expect(changes[i]!.fromB).toBeGreaterThanOrEqual(changes[i - 1]!.toB)
+    }
+
+    // p1 nodeSize=5 (open+AAA+close), p2 spans [5, 10], p3 spans [10, 15]
+    // None of the changes should touch the middle paragraph at [5, 10]
+    for (const change of changes) {
+      const overlapsMiddle = change.fromA < 10 && change.toA > 5
+      expect(overlapsMiddle).toBe(false)
+    }
+  })
+
+  it('insertion between unchanged paragraphs is a pure insert', () => {
+    const oldDoc = doc(p(text('A')), p(text('C')))
+    const newDoc = doc(p(text('A')), p(text('B')), p(text('C')))
+
+    const changes = computeDocDiff(oldDoc, newDoc)
+    expect(changes.length).toBe(1)
+
+    const change = changes[0]!
+    // Pure insert: fromA === toA
+    expect(change.fromA).toBe(change.toA)
+    // fromB < toB: insertion
+    expect(change.fromB).toBeLessThan(change.toB)
+  })
+
+  it('deletion between unchanged paragraphs is a pure delete', () => {
+    const oldDoc = doc(p(text('A')), p(text('B')), p(text('C')))
+    const newDoc = doc(p(text('A')), p(text('C')))
+
+    const changes = computeDocDiff(oldDoc, newDoc)
+    expect(changes.length).toBe(1)
+
+    const change = changes[0]!
+    // Pure delete: fromB === toB
+    expect(change.fromB).toBe(change.toB)
+    // fromA < toA: deletion
+    expect(change.fromA).toBeLessThan(change.toA)
+  })
+
+  it('list item text edit recurses into the list', () => {
+    // bullet_list is a single top-level child, but our algorithm recurses
+    // into container nodes. Editing one item's text should produce a small
+    // change inside that item, not a huge one covering the whole list.
+    const oldDoc = doc(ul(li(p(text('one'))), li(p(text('two')))))
+    const newDoc = doc(ul(li(p(text('ONE'))), li(p(text('two')))))
+
+    const changes = computeDocDiff(oldDoc, newDoc)
+    expect(changes.length).toBeGreaterThan(0)
+
+    // The change(s) should not cover the entire bullet_list
+    // bullet_list nodeSize for 2 items with one word each is quite small,
+    // but the whole-list replacement would span [0, ul.nodeSize]
+    const listOuterSize = oldDoc.child(0).nodeSize
+    for (const change of changes) {
+      // No single change should span the entire list
+      expect(change.toA - change.fromA).toBeLessThan(listOuterSize)
+    }
+  })
+
+  it('list item text edit + new list item produces two separate changes', () => {
+    // The main regression test: modifying an item AND adding a new one
+    // should produce two changes, not one big merged change.
+    const oldDoc = doc(ul(li(p(text('one'))), li(p(text('two')))))
+    const newDoc = doc(
+      ul(li(p(text('ONE'))), li(p(text('two'))), li(p(text('three'))))
+    )
+
+    const changes = computeDocDiff(oldDoc, newDoc)
+    expect(changes.length).toBeGreaterThanOrEqual(2)
+
+    // Sorted and non-overlapping
+    for (let i = 1; i < changes.length; i++) {
+      expect(changes[i]!.fromA).toBeGreaterThanOrEqual(changes[i - 1]!.toA)
+    }
+  })
+
+  it('blockquote text edit recurses into the blockquote', () => {
+    // blockquote is not in the test schema, but we can test with nested
+    // paragraph-in-textblock pattern. Use the existing ul/li/p instead.
+    const oldDoc = doc(ul(li(p(text('hello world')))))
+    const newDoc = doc(ul(li(p(text('hello universe')))))
+
+    const changes = computeDocDiff(oldDoc, newDoc)
+    expect(changes.length).toBeGreaterThan(0)
+
+    // The change should be inside the inner paragraph, not the whole list
+    const listOuterSize = oldDoc.child(0).nodeSize
+    for (const change of changes) {
+      expect(change.toA - change.fromA).toBeLessThan(listOuterSize)
+    }
+  })
+
+  it('unchanged middle block is not touched by diffs', () => {
+    const oldDoc = doc(
+      heading(1, text('Title')),
+      p(text('middle')),
+      heading(2, text('End'))
+    )
+    const newDoc = doc(
+      heading(1, text('TITLE')),
+      p(text('middle')),
+      heading(2, text('END'))
+    )
+
+    const changes = computeDocDiff(oldDoc, newDoc)
+    expect(changes.length).toBeGreaterThanOrEqual(2)
+
+    // Middle paragraph 'middle' starts after h1 (nodeSize 7: open + 'Title' + close)
+    // h1 nodeSize = 7, so p starts at 7, p nodeSize = 8, p ends at 15
+    const h1Size = oldDoc.child(0).nodeSize
+    const pSize = oldDoc.child(1).nodeSize
+    const pStart = h1Size
+    const pEnd = pStart + pSize
+    for (const change of changes) {
+      const overlapsMiddle = change.fromA < pEnd && change.toA > pStart
+      expect(overlapsMiddle).toBe(false)
+    }
+  })
+
+  it('table cell edit recurses into the table', () => {
+    const oldDoc = doc(
+      table(tr(td(text('A')), td(text('B'))), tr(td(text('1')), td(text('2'))))
+    )
+    const newDoc = doc(
+      table(tr(td(text('A')), td(text('B'))), tr(td(text('1')), td(text('X'))))
+    )
+
+    const changes = computeDocDiff(oldDoc, newDoc)
+    expect(changes.length).toBeGreaterThan(0)
+
+    // The change should be smaller than the entire table
+    const tableSize = oldDoc.child(0).nodeSize
+    for (const change of changes) {
+      expect(change.toA - change.fromA).toBeLessThan(tableSize)
+    }
+  })
+
+  it('reordering produces smaller changes than full replacement', () => {
+    const oldDoc = doc(p(text('A')), p(text('B')), p(text('C')))
+    const newDoc = doc(p(text('B')), p(text('A')), p(text('C')))
+
+    const changes = computeDocDiff(oldDoc, newDoc)
+    expect(changes.length).toBeGreaterThan(0)
+
+    // Sorted and non-overlapping
+    for (let i = 1; i < changes.length; i++) {
+      expect(changes[i]!.fromA).toBeGreaterThanOrEqual(changes[i - 1]!.toA)
+    }
+  })
+
+  it('changes are sorted and non-overlapping (invariant)', () => {
+    // Complex case with many independent edits
+    const oldDoc = doc(
+      heading(1, text('Title')),
+      p(text('intro')),
+      ul(li(p(text('a'))), li(p(text('b')))),
+      p(text('outro'))
+    )
+    const newDoc = doc(
+      heading(2, text('Title')), // level change
+      p(text('intro updated')),
+      ul(li(p(text('A'))), li(p(text('b'))), li(p(text('c')))),
+      p(text('outro'))
+    )
+
+    const changes = computeDocDiff(oldDoc, newDoc)
+    expect(changes.length).toBeGreaterThan(0)
+
+    for (let i = 1; i < changes.length; i++) {
+      expect(changes[i]!.fromA).toBeGreaterThanOrEqual(changes[i - 1]!.toA)
+      expect(changes[i]!.fromB).toBeGreaterThanOrEqual(changes[i - 1]!.toB)
+    }
+  })
+})

--- a/packages/plugins/plugin-diff/src/__test__/diff-compute.spec.ts
+++ b/packages/plugins/plugin-diff/src/__test__/diff-compute.spec.ts
@@ -736,9 +736,9 @@ describe('computeDocDiff - per-block matching', () => {
     }
   })
 
-  it('blockquote text edit recurses into the blockquote', () => {
-    // blockquote is not in the test schema, but we can test with nested
-    // paragraph-in-textblock pattern. Use the existing ul/li/p instead.
+  it('nested list item text edit recurses into the inner paragraph', () => {
+    // Regression test for recursion through nested container nodes using
+    // the existing ul/li/p structure from this test schema.
     const oldDoc = doc(ul(li(p(text('hello world')))))
     const newDoc = doc(ul(li(p(text('hello universe')))))
 

--- a/packages/plugins/plugin-diff/src/diff-compute.ts
+++ b/packages/plugins/plugin-diff/src/diff-compute.ts
@@ -313,43 +313,57 @@ function pureInsert(child: TopChild, anchorA: number, absB: number): Change {
 /// Large-container fallback: diff the container's content directly with
 /// a single ChangeSet, without wrapping. Positions returned by the
 /// changeset are relative to the container's content and get translated
-/// to absolute doc positions via the container's `contentStart`.
+/// to absolute doc positions via the caller-supplied `contentStart`.
 function diffContainerContent(
-  oldPair: ParentPair,
-  newPair: ParentPair,
+  oldNode: Node,
+  newNode: Node,
+  oldContentStart: number,
+  newContentStart: number,
   env: LcsEnv
 ): Change[] {
   const step = new ReplaceStep(
     0,
-    oldPair.node.content.size,
-    new Slice(newPair.node.content, 0, 0)
+    oldNode.content.size,
+    new Slice(newNode.content, 0, 0)
   )
-  const cs = ChangeSet.create(oldPair.node, undefined, env.encoder).addSteps(
-    newPair.node,
+  const cs = ChangeSet.create(oldNode, undefined, env.encoder).addSteps(
+    newNode,
     [step.getMap()],
     null
   )
   return cs.changes.map((c) =>
-    translateChange(c, oldPair.contentStart, newPair.contentStart)
+    translateChange(c, oldContentStart, newContentStart)
   )
 }
 
 /// Diff two container nodes by matching their children with LCS.
 /// Returns changes with absolute positions (relative to the full doc).
+///
+/// The large-container guard runs against raw `childCount` so we never
+/// eagerly compute signatures for a subtree that's about to be handled
+/// by the single-step fallback.
 function diffChildrenLcs(
-  oldPair: ParentPair,
-  newPair: ParentPair,
+  oldNode: Node,
+  newNode: Node,
+  oldContentStart: number,
+  newContentStart: number,
   env: LcsEnv
 ): Change[] {
-  // Guard against very large lists — fall back to a single ChangeSet
-  // computed directly on the container (no self-wrapping).
   if (
-    oldPair.content.length > LCS_MAX_CHILDREN ||
-    newPair.content.length > LCS_MAX_CHILDREN
+    oldNode.childCount > LCS_MAX_CHILDREN ||
+    newNode.childCount > LCS_MAX_CHILDREN
   ) {
-    return diffContainerContent(oldPair, newPair, env)
+    return diffContainerContent(
+      oldNode,
+      newNode,
+      oldContentStart,
+      newContentStart,
+      env
+    )
   }
 
+  const oldPair = makeParentPair(oldNode, oldContentStart, env)
+  const newPair = makeParentPair(newNode, newContentStart, env)
   const matches = lcsMatch(oldPair.content, newPair.content)
   const result: Change[] = []
   let i = 0
@@ -456,11 +470,7 @@ function diffSameTypePair(
     )
   }
 
-  return diffChildrenLcs(
-    makeParentPair(oldChild.node, absA + 1, env),
-    makeParentPair(newChild.node, absB + 1, env),
-    env
-  )
+  return diffChildrenLcs(oldChild.node, newChild.node, absA + 1, absB + 1, env)
 }
 
 /// Quick check for attr differences between two same-type nodes, using
@@ -518,8 +528,10 @@ function isFullDocRange(
 /// When `options.range` is provided, only the specified region is diffed.
 ///
 /// Uses per-block LCS matching (recursing into container nodes like
-/// bullet_list, blockquote, table) for the full-doc path. Falls back to
-/// a single-step diff when `range` is provided.
+/// bullet_list, blockquote, table). Falls back to a single-step diff
+/// when `options.range` actually restricts the diff to a sub-region of
+/// the document; a range that happens to cover the full document still
+/// takes the per-block path.
 export function computeDocDiff(
   oldDoc: Node,
   newDoc: Node,
@@ -527,16 +539,14 @@ export function computeDocDiff(
 ): readonly Change[] {
   const encoder = createDiffEncoder(options?.ignoreAttrs)
 
-  // Range option: use legacy single-step path for correctness.
+  // Sub-region range: use the legacy single-step path so the caller's
+  // boundary is honoured exactly. A range that covers the whole doc is
+  // treated as if no range were given.
   if (!isFullDocRange(options, oldDoc.content.size, newDoc.content.size)) {
     return legacyDiff(oldDoc, newDoc, options, encoder)
   }
 
   const env: LcsEnv = { encoder, sigCache: new WeakMap<Node, string>() }
   // Top-level diff: parent content starts at position 0 in the doc.
-  return diffChildrenLcs(
-    makeParentPair(oldDoc, 0, env),
-    makeParentPair(newDoc, 0, env),
-    env
-  )
+  return diffChildrenLcs(oldDoc, newDoc, 0, 0, env)
 }

--- a/packages/plugins/plugin-diff/src/diff-compute.ts
+++ b/packages/plugins/plugin-diff/src/diff-compute.ts
@@ -1,8 +1,8 @@
-import type { Change } from '@milkdown/prose/changeset'
+import type { Change, TokenEncoder } from '@milkdown/prose/changeset'
 import type { Mark, Node } from '@milkdown/prose/model'
 
-import { ChangeSet } from '@milkdown/prose/changeset'
-import { Slice } from '@milkdown/prose/model'
+import { ChangeSet, Change as ChangeCtor } from '@milkdown/prose/changeset'
+import { Fragment, Slice } from '@milkdown/prose/model'
 import { ReplaceStep } from '@milkdown/prose/transform'
 
 /// A map of node type names to arrays of attribute keys that should be
@@ -10,11 +10,34 @@ import { ReplaceStep } from '@milkdown/prose/transform'
 /// skip the `id` attribute on heading nodes.
 export type DiffIgnoreAttrs = Record<string, string[]>
 
+/// A symmetric range that restricts the diff to a sub-region of both documents.
+/// The same `from`/`to` positions are used in both old and new docs.
+/// Omitted fields default to 0 (start) or content.size (end).
+export interface ComputeDiffRange {
+  from?: number
+  to?: number
+}
+
+/// Options for `computeDocDiff`.
+export interface ComputeDocDiffOptions {
+  /// Restrict the diff to a sub-region of both documents.
+  range?: ComputeDiffRange
+  /// Map of node type names to attribute keys to ignore when diffing.
+  ignoreAttrs?: DiffIgnoreAttrs
+}
+
+/// Maximum children count per container for which we run LCS matching.
+/// Beyond this threshold we fall back to the legacy single-step path to
+/// avoid O(n*m) cost.
+const LCS_MAX_CHILDREN = 500
+
 /**
  * Create a token encoder that encodes ALL non-default attrs for every node,
  * but skips attrs listed in the `ignoreAttrs` map for a given node type.
  */
-function createDiffEncoder(ignoreAttrs: DiffIgnoreAttrs = {}) {
+function createDiffEncoder(
+  ignoreAttrs: DiffIgnoreAttrs = {}
+): TokenEncoder<null> {
   // Cache individual mark tokens and combined mark-set tokens.
   // ProseMirror marks are ordered by type rank and structurally shared,
   // so the same readonly Mark[] reference is reused for identical mark sets.
@@ -44,14 +67,13 @@ function createDiffEncoder(ignoreAttrs: DiffIgnoreAttrs = {}) {
 
   return {
     encodeCharacter: (char: number, marks: readonly Mark[]) => {
-      if (marks.length === 0) return char
+      if (marks.length === 0) return char as unknown as null
       let combined = markSetCache.get(marks)
       if (combined == null) {
-        // ProseMirror marks are already sorted by type rank, so no sort needed
         combined = marks.map(encodeMark).join(',')
         markSetCache.set(marks, combined)
       }
-      return `${char}:${combined}`
+      return `${char}:${combined}` as unknown as null
     },
     encodeNodeStart: (node: Node) => {
       const attrs = node.attrs
@@ -67,10 +89,10 @@ function createDiffEncoder(ignoreAttrs: DiffIgnoreAttrs = {}) {
           for (const key of relevantKeys.sort()) {
             encoded[key] = attrs[key]
           }
-          return `${node.type.name}:${JSON.stringify(encoded)}`
+          return `${node.type.name}:${JSON.stringify(encoded)}` as unknown as null
         }
       }
-      return node.type.name
+      return node.type.name as unknown as null
     },
     encodeNodeEnd: (node: Node) => {
       const schema = node.type.schema
@@ -81,34 +103,366 @@ function createDiffEncoder(ignoreAttrs: DiffIgnoreAttrs = {}) {
       if (id == null)
         cache[node.type.name] = id =
           Object.keys(schema.nodes).indexOf(node.type.name) + 1
-      return -id
+      return -id as unknown as null
     },
     compareTokens: (a: unknown, b: unknown) => a === b,
   }
 }
 
-/// A symmetric range that restricts the diff to a sub-region of both documents.
-/// The same `from`/`to` positions are used in both old and new docs.
-/// Omitted fields default to 0 (start) or content.size (end).
-export interface ComputeDiffRange {
-  from?: number
-  to?: number
+/// Compute a structural signature for a node by walking it with the
+/// token encoder. Two nodes with the same signature are considered
+/// equal for LCS matching (respects ignoreAttrs via the encoder).
+function nodeSignature(
+  node: Node,
+  encoder: TokenEncoder<null>,
+  cache: WeakMap<Node, string>
+): string {
+  const cached = cache.get(node)
+  if (cached != null) return cached
+
+  const parts: string[] = [String(encoder.encodeNodeStart(node))]
+  if (node.isText) {
+    const text = node.text!
+    for (let i = 0; i < text.length; i++) {
+      parts.push(
+        ':' + String(encoder.encodeCharacter(text.charCodeAt(i), node.marks))
+      )
+    }
+  } else {
+    node.content.forEach((child) => {
+      parts.push('/' + nodeSignature(child, encoder, cache))
+    })
+  }
+  parts.push('\\' + String(encoder.encodeNodeEnd(node)))
+
+  const sig = parts.join('')
+  cache.set(node, sig)
+  return sig
 }
 
-/// Options for `computeDocDiff`.
-export interface ComputeDocDiffOptions {
-  /// Restrict the diff to a sub-region of both documents.
-  range?: ComputeDiffRange
-  /// Map of node type names to attribute keys to ignore when diffing.
-  ignoreAttrs?: DiffIgnoreAttrs
+interface TopChild {
+  node: Node
+  offset: number // offset inside parent content (before the child)
+  size: number // node.nodeSize
+  signature: string
 }
 
-/// Compute fine-grained changes between two ProseMirror documents.
-/// When `options.range` is provided, only the specified region is diffed.
-export function computeDocDiff(
+/// A parent container paired with its absolute content-start position in
+/// the full doc. `content` is the list of LCS-ready children, computed once.
+interface ParentPair {
+  node: Node
+  contentStart: number
+  content: TopChild[]
+}
+
+/// Shared state carried through the per-block recursion.
+interface LcsEnv {
+  encoder: TokenEncoder<null>
+  sigCache: WeakMap<Node, string>
+}
+
+function makeParentPair(
+  node: Node,
+  contentStart: number,
+  env: LcsEnv
+): ParentPair {
+  const content: TopChild[] = []
+  let offset = 0
+  node.content.forEach((child) => {
+    content.push({
+      node: child,
+      offset,
+      size: child.nodeSize,
+      signature: nodeSignature(child, env.encoder, env.sigCache),
+    })
+    offset += child.nodeSize
+  })
+  return { node, contentStart, content }
+}
+
+/// LCS DP over two arrays of TopChildren matched by signature.
+/// Returns list of matched index pairs [oldIdx, newIdx] in order.
+function lcsMatch(
+  oldList: TopChild[],
+  newList: TopChild[]
+): Array<[number, number]> {
+  const n = oldList.length
+  const m = newList.length
+  // DP table
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    Array.from({ length: m + 1 }, () => 0)
+  )
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      if (oldList[i]!.signature === newList[j]!.signature) {
+        dp[i]![j] = dp[i + 1]![j + 1]! + 1
+      } else {
+        dp[i]![j] = Math.max(dp[i + 1]![j]!, dp[i]![j + 1]!)
+      }
+    }
+  }
+  // Backtrack
+  const matches: Array<[number, number]> = []
+  let i = 0
+  let j = 0
+  while (i < n && j < m) {
+    if (oldList[i]!.signature === newList[j]!.signature) {
+      matches.push([i, j])
+      i++
+      j++
+    } else if (dp[i + 1]![j]! >= dp[i]![j + 1]!) {
+      i++
+    } else {
+      j++
+    }
+  }
+  return matches
+}
+
+/// Decide whether a matched pair can be recursed into.
+/// Container nodes (non-textblock, non-code, non-atom) with matching type
+/// are recursed; textblocks and atoms go through the per-pair ChangeSet.
+function canRecurse(oldNode: Node, newNode: Node): boolean {
+  if (oldNode.type !== newNode.type) return false
+  const type = oldNode.type
+  if (type.isTextblock) return false
+  if (type.isAtom) return false
+  if (type.spec.code === true) return false
+  if (!type.isBlock) return false
+  return true
+}
+
+/// Create a Change with translated positions from a sub-ChangeSet change.
+function translateChange(change: Change, absA: number, absB: number): Change {
+  return ChangeCtor.fromJSON({
+    fromA: change.fromA + absA,
+    toA: change.toA + absA,
+    fromB: change.fromB + absB,
+    toB: change.toB + absB,
+    deleted: change.deleted.map((s) => ({ length: s.length, data: s.data })),
+    inserted: change.inserted.map((s) => ({ length: s.length, data: s.data })),
+  })
+}
+
+/// A node to diff, paired with its parent (used as a wrapper) and its
+/// absolute position in the full doc.
+interface PairSide {
+  node: Node
+  parent: Node
+  abs: number
+}
+
+/// Diff a single pair of nodes using a per-pair ChangeSet.
+/// Wraps both nodes in a copy of their parent so positions stay valid.
+function diffPairWithChangeSet(
+  oldSide: PairSide,
+  newSide: PairSide,
+  env: LcsEnv
+): Change[] {
+  const wrapperOld = oldSide.parent.copy(Fragment.from(oldSide.node))
+  const wrapperNew = newSide.parent.copy(Fragment.from(newSide.node))
+  const step = new ReplaceStep(
+    0,
+    wrapperOld.content.size,
+    new Slice(wrapperNew.content, 0, 0)
+  )
+  const cs = ChangeSet.create(wrapperOld, undefined, env.encoder).addSteps(
+    wrapperNew,
+    [step.getMap()],
+    null
+  )
+  return cs.changes.map((c) => translateChange(c, oldSide.abs, newSide.abs))
+}
+
+/// Absolute position where an unmatched child should anchor its
+/// counterpart in the other doc. When the cursor still points at a child,
+/// use that child's offset. Otherwise fall back to the right edge of the
+/// previous child, or the parent content size if the list is empty.
+function anchorOffset(pair: ParentPair, cursor: number): number {
+  const list = pair.content
+  if (cursor < list.length) return pair.contentStart + list[cursor]!.offset
+  if (cursor > 0) {
+    const prev = list[cursor - 1]!
+    return pair.contentStart + prev.offset + prev.size
+  }
+  return pair.contentStart + pair.node.content.size
+}
+
+function pureDelete(child: TopChild, absA: number, anchorB: number): Change {
+  return ChangeCtor.fromJSON({
+    fromA: absA,
+    toA: absA + child.size,
+    fromB: anchorB,
+    toB: anchorB,
+    deleted: [{ length: child.size, data: null }],
+    inserted: [],
+  })
+}
+
+function pureInsert(child: TopChild, anchorA: number, absB: number): Change {
+  return ChangeCtor.fromJSON({
+    fromA: anchorA,
+    toA: anchorA,
+    fromB: absB,
+    toB: absB + child.size,
+    deleted: [],
+    inserted: [{ length: child.size, data: null }],
+  })
+}
+
+/// Diff two container nodes by matching their children with LCS.
+/// Returns changes with absolute positions (relative to the full doc).
+function diffChildrenLcs(
+  oldPair: ParentPair,
+  newPair: ParentPair,
+  env: LcsEnv
+): Change[] {
+  // Guard against very large lists — fall back to single-step diff
+  if (
+    oldPair.content.length > LCS_MAX_CHILDREN ||
+    newPair.content.length > LCS_MAX_CHILDREN
+  ) {
+    return diffPairWithChangeSet(
+      {
+        node: oldPair.node,
+        parent: oldPair.node,
+        abs: oldPair.contentStart - 1,
+      },
+      {
+        node: newPair.node,
+        parent: newPair.node,
+        abs: newPair.contentStart - 1,
+      },
+      env
+    )
+  }
+
+  const matches = lcsMatch(oldPair.content, newPair.content)
+  const result: Change[] = []
+  let i = 0
+  let j = 0
+  for (const [mi, mj] of matches) {
+    processGap(
+      oldPair,
+      newPair,
+      { oldStart: i, oldEnd: mi, newStart: j, newEnd: mj },
+      env,
+      result
+    )
+    i = mi + 1
+    j = mj + 1
+  }
+  processGap(
+    oldPair,
+    newPair,
+    {
+      oldStart: i,
+      oldEnd: oldPair.content.length,
+      newStart: j,
+      newEnd: newPair.content.length,
+    },
+    env,
+    result
+  )
+  return result
+}
+
+interface GapWindow {
+  oldStart: number
+  oldEnd: number
+  newStart: number
+  newEnd: number
+}
+
+/// Process a gap of unmatched children: greedily align same-typed nodes
+/// into pairs, emit pure insert/delete for leftovers.
+function processGap(
+  oldPair: ParentPair,
+  newPair: ParentPair,
+  window: GapWindow,
+  env: LcsEnv,
+  out: Change[]
+): void {
+  const oldList = oldPair.content
+  const newList = newPair.content
+  let oi = window.oldStart
+  let ni = window.newStart
+
+  while (oi < window.oldEnd || ni < window.newEnd) {
+    const oldChild = oi < window.oldEnd ? oldList[oi]! : null
+    const newChild = ni < window.newEnd ? newList[ni]! : null
+    const sameType =
+      oldChild && newChild && oldChild.node.type === newChild.node.type
+
+    if (oldChild && newChild && sameType) {
+      out.push(...diffSameTypePair(oldPair, newPair, oldChild, newChild, env))
+      oi++
+      ni++
+      continue
+    }
+
+    if (oldChild && (!newChild || !sameType)) {
+      const absA = oldPair.contentStart + oldChild.offset
+      out.push(pureDelete(oldChild, absA, anchorOffset(newPair, ni)))
+      oi++
+      continue
+    }
+
+    if (newChild) {
+      const absB = newPair.contentStart + newChild.offset
+      out.push(pureInsert(newChild, anchorOffset(oldPair, oi), absB))
+      ni++
+    }
+  }
+}
+
+/// Diff a pair of same-typed children: recurse into containers when
+/// possible, otherwise fall back to a per-pair ChangeSet.
+function diffSameTypePair(
+  oldPair: ParentPair,
+  newPair: ParentPair,
+  oldChild: TopChild,
+  newChild: TopChild,
+  env: LcsEnv
+): Change[] {
+  const absA = oldPair.contentStart + oldChild.offset
+  const absB = newPair.contentStart + newChild.offset
+
+  // Textblocks, atoms, code, and nodes whose own attrs differ all go
+  // through the per-pair ChangeSet. Recursion would miss attribute-level
+  // differences on the container node itself.
+  const shouldRecurse =
+    canRecurse(oldChild.node, newChild.node) &&
+    attrsEqual(oldChild.node, newChild.node, env.encoder)
+
+  if (!shouldRecurse) {
+    return diffPairWithChangeSet(
+      { node: oldChild.node, parent: oldPair.node, abs: absA },
+      { node: newChild.node, parent: newPair.node, abs: absB },
+      env
+    )
+  }
+
+  return diffChildrenLcs(
+    makeParentPair(oldChild.node, absA + 1, env),
+    makeParentPair(newChild.node, absB + 1, env),
+    env
+  )
+}
+
+/// Quick check for attr differences between two same-type nodes, using
+/// the encoder's node-start token (which respects ignoreAttrs).
+function attrsEqual(a: Node, b: Node, encoder: TokenEncoder<null>): boolean {
+  return encoder.encodeNodeStart(a) === encoder.encodeNodeStart(b)
+}
+
+/// Legacy single-step diff implementation. Used for the `range` option
+/// and as a fallback for large documents.
+function legacyDiff(
   oldDoc: Node,
   newDoc: Node,
-  options?: ComputeDocDiffOptions
+  options: ComputeDocDiffOptions | undefined,
+  encoder: TokenEncoder<null>
 ): readonly Change[] {
   const oldSize = oldDoc.content.size
   const newSize = newDoc.content.size
@@ -122,13 +476,50 @@ export function computeDocDiff(
     toOld,
     new Slice(newDoc.content.cut(from, toNew), 0, 0)
   )
-
-  const encoder = createDiffEncoder(options?.ignoreAttrs)
   const changeSet = ChangeSet.create(oldDoc, undefined, encoder).addSteps(
     newDoc,
     [step.getMap()],
     null
   )
-
   return changeSet.changes
+}
+
+/// Returns true if `options.range` is effectively the full document.
+function isFullDocRange(
+  options: ComputeDocDiffOptions | undefined,
+  oldSize: number,
+  newSize: number
+): boolean {
+  const range = options?.range
+  if (!range) return true
+  const from = range.from ?? 0
+  const to = range.to ?? Math.max(oldSize, newSize)
+  return from <= 0 && to >= Math.max(oldSize, newSize)
+}
+
+/// Compute fine-grained changes between two ProseMirror documents.
+/// When `options.range` is provided, only the specified region is diffed.
+///
+/// Uses per-block LCS matching (recursing into container nodes like
+/// bullet_list, blockquote, table) for the full-doc path. Falls back to
+/// a single-step diff when `range` is provided.
+export function computeDocDiff(
+  oldDoc: Node,
+  newDoc: Node,
+  options?: ComputeDocDiffOptions
+): readonly Change[] {
+  const encoder = createDiffEncoder(options?.ignoreAttrs)
+
+  // Range option: use legacy single-step path for correctness.
+  if (!isFullDocRange(options, oldDoc.content.size, newDoc.content.size)) {
+    return legacyDiff(oldDoc, newDoc, options, encoder)
+  }
+
+  const env: LcsEnv = { encoder, sigCache: new WeakMap<Node, string>() }
+  // Top-level diff: parent content starts at position 0 in the doc.
+  return diffChildrenLcs(
+    makeParentPair(oldDoc, 0, env),
+    makeParentPair(newDoc, 0, env),
+    env
+  )
 }

--- a/packages/plugins/plugin-diff/src/diff-compute.ts
+++ b/packages/plugins/plugin-diff/src/diff-compute.ts
@@ -37,7 +37,7 @@ const LCS_MAX_CHILDREN = 500
  */
 function createDiffEncoder(
   ignoreAttrs: DiffIgnoreAttrs = {}
-): TokenEncoder<null> {
+): TokenEncoder<string | number> {
   // Cache individual mark tokens and combined mark-set tokens.
   // ProseMirror marks are ordered by type rank and structurally shared,
   // so the same readonly Mark[] reference is reused for identical mark sets.
@@ -67,13 +67,13 @@ function createDiffEncoder(
 
   return {
     encodeCharacter: (char: number, marks: readonly Mark[]) => {
-      if (marks.length === 0) return char as unknown as null
+      if (marks.length === 0) return char
       let combined = markSetCache.get(marks)
       if (combined == null) {
         combined = marks.map(encodeMark).join(',')
         markSetCache.set(marks, combined)
       }
-      return `${char}:${combined}` as unknown as null
+      return `${char}:${combined}`
     },
     encodeNodeStart: (node: Node) => {
       const attrs = node.attrs
@@ -89,10 +89,10 @@ function createDiffEncoder(
           for (const key of relevantKeys.sort()) {
             encoded[key] = attrs[key]
           }
-          return `${node.type.name}:${JSON.stringify(encoded)}` as unknown as null
+          return `${node.type.name}:${JSON.stringify(encoded)}`
         }
       }
-      return node.type.name as unknown as null
+      return node.type.name
     },
     encodeNodeEnd: (node: Node) => {
       const schema = node.type.schema
@@ -103,9 +103,9 @@ function createDiffEncoder(
       if (id == null)
         cache[node.type.name] = id =
           Object.keys(schema.nodes).indexOf(node.type.name) + 1
-      return -id as unknown as null
+      return -id
     },
-    compareTokens: (a: unknown, b: unknown) => a === b,
+    compareTokens: (a, b) => a === b,
   }
 }
 
@@ -114,7 +114,7 @@ function createDiffEncoder(
 /// equal for LCS matching (respects ignoreAttrs via the encoder).
 function nodeSignature(
   node: Node,
-  encoder: TokenEncoder<null>,
+  encoder: TokenEncoder<string | number>,
   cache: WeakMap<Node, string>
 ): string {
   const cached = cache.get(node)
@@ -157,7 +157,7 @@ interface ParentPair {
 
 /// Shared state carried through the per-block recursion.
 interface LcsEnv {
-  encoder: TokenEncoder<null>
+  encoder: TokenEncoder<string | number>
   sigCache: WeakMap<Node, string>
 }
 
@@ -310,6 +310,30 @@ function pureInsert(child: TopChild, anchorA: number, absB: number): Change {
   })
 }
 
+/// Large-container fallback: diff the container's content directly with
+/// a single ChangeSet, without wrapping. Positions returned by the
+/// changeset are relative to the container's content and get translated
+/// to absolute doc positions via the container's `contentStart`.
+function diffContainerContent(
+  oldPair: ParentPair,
+  newPair: ParentPair,
+  env: LcsEnv
+): Change[] {
+  const step = new ReplaceStep(
+    0,
+    oldPair.node.content.size,
+    new Slice(newPair.node.content, 0, 0)
+  )
+  const cs = ChangeSet.create(oldPair.node, undefined, env.encoder).addSteps(
+    newPair.node,
+    [step.getMap()],
+    null
+  )
+  return cs.changes.map((c) =>
+    translateChange(c, oldPair.contentStart, newPair.contentStart)
+  )
+}
+
 /// Diff two container nodes by matching their children with LCS.
 /// Returns changes with absolute positions (relative to the full doc).
 function diffChildrenLcs(
@@ -317,24 +341,13 @@ function diffChildrenLcs(
   newPair: ParentPair,
   env: LcsEnv
 ): Change[] {
-  // Guard against very large lists — fall back to single-step diff
+  // Guard against very large lists — fall back to a single ChangeSet
+  // computed directly on the container (no self-wrapping).
   if (
     oldPair.content.length > LCS_MAX_CHILDREN ||
     newPair.content.length > LCS_MAX_CHILDREN
   ) {
-    return diffPairWithChangeSet(
-      {
-        node: oldPair.node,
-        parent: oldPair.node,
-        abs: oldPair.contentStart - 1,
-      },
-      {
-        node: newPair.node,
-        parent: newPair.node,
-        abs: newPair.contentStart - 1,
-      },
-      env
-    )
+    return diffContainerContent(oldPair, newPair, env)
   }
 
   const matches = lcsMatch(oldPair.content, newPair.content)
@@ -452,7 +465,11 @@ function diffSameTypePair(
 
 /// Quick check for attr differences between two same-type nodes, using
 /// the encoder's node-start token (which respects ignoreAttrs).
-function attrsEqual(a: Node, b: Node, encoder: TokenEncoder<null>): boolean {
+function attrsEqual(
+  a: Node,
+  b: Node,
+  encoder: TokenEncoder<string | number>
+): boolean {
   return encoder.encodeNodeStart(a) === encoder.encodeNodeStart(b)
 }
 
@@ -462,7 +479,7 @@ function legacyDiff(
   oldDoc: Node,
   newDoc: Node,
   options: ComputeDocDiffOptions | undefined,
-  encoder: TokenEncoder<null>
+  encoder: TokenEncoder<string | number>
 ): readonly Change[] {
   const oldSize = oldDoc.content.size
   const newSize = newDoc.content.size


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

`computeDocDiff` previously ran a single `ReplaceStep` over the whole document, so ProseMirror's changeset library collapsed any nearby edits into one big merged change. Editing a list item and adding another one ended up rendering as one giant widget covering the whole list, which the diff-review UI can't split.

This PR replaces the top-level step with an LCS matcher over the old and new doc's top-level children, then recurses into container nodes (`bullet_list`, `blockquote`, `table`, `table_row`, ...). Only leaf nodes — textblocks, atoms, code blocks, and nodes whose own attrs differ — fall through to a per-pair `ChangeSet`. The `range` option still uses the legacy single-step path.

The new, finer-grained diff also surfaced a few latent rendering bugs in `@milkdown/components` that I fixed along the way:

- `hasBlockContent` treated the wrapper open-token of a list_item as block content, so a single attribute flip on a task list item wrapped the entire `<ul>` in a `removed-block` decoration.
- `mergeBlockChanges` expanded pure inserts/deletes adjacent to a table into the table, producing a duplicated added-widget and requiring multiple Accept clicks to clear one change.
- Pure inserts at the doc end were spliced after Crepe's trailing empty paragraph placeholder, which pushed the placeholder out of its trailing slot and left an orphaned empty removal widget on the next recompute.

Tests for the per-block matcher live in `plugin-diff`, and the rendering regressions each got a dedicated test in a new `components/src/diff/__tests__/diff-utils.spec.ts`.

## How did you test this change?

- Ran the vitest suites in `packages/plugins/plugin-diff`, `packages/plugins/plugin-streaming`, and `packages/components`.
- Ran the Playwright suite in `e2e`.
- Manually exercised the Crepe Diff Review story in Storybook: list item edits render as inline changes, the task list `<ul>` is no longer wrapped, tables show one added widget, and accepting the "New Section" insertion no longer leaves an empty removal widget behind.
- Regression tests for the three rendering bugs were verified to fail when the relevant fix is stashed and pass when it is restored.