### PR TITLE
feat: per-block diff for the range option

### DIFF
--- a/packages/plugins/plugin-diff/src/__test__/diff-compute.spec.ts
+++ b/packages/plugins/plugin-diff/src/__test__/diff-compute.spec.ts
@@ -943,6 +943,36 @@ describe('computeDocDiff - range option, per-block', () => {
     expect(changes.length).toBeGreaterThan(0)
   })
 
+  it('sub-range with mismatched ancestor start position falls back to legacy', () => {
+    // Both docs have a bullet_list with the same children, but the
+    // prefix paragraph differs in size, so the ul sits at different
+    // absolute positions in the two docs. The same numeric range
+    // [16, 21] still resolves to depth 1 inside the ul in both docs
+    // (sharedDepth = 1) and lies on li boundaries in both, but
+    //
+    //   $oldFrom.start(1) = 11   (old ul.content starts at 11)
+    //   $newFrom.start(1) = 16   (new ul.content starts at 16)
+    //
+    // Without the absolute-start check in tryBuildRangeSubtree the cut
+    // would use mismatched local offsets and silently compare the wrong
+    // content. The check rejects the subtree extraction and we fall
+    // back to legacyDiff for correctness. This exercises the
+    // ancestor-chain mismatch branch of the precondition loop.
+    const oldDoc = doc(
+      p(text('xxxxxxxx')),
+      ul(li(p(text('a'))), li(p(text('b'))))
+    )
+    const newDoc = doc(
+      p(text('xxxxxxxxxxxxx')),
+      ul(li(p(text('a'))), li(p(text('b'))))
+    )
+
+    const changes = computeDocDiff(oldDoc, newDoc, {
+      range: { from: 16, to: 21 },
+    })
+    expect(changes.length).toBeGreaterThan(0)
+  })
+
   it('empty sub-range returns no changes', () => {
     const oldDoc = doc(p(text('a')), p(text('b')))
     const newDoc = doc(p(text('a')), p(text('B')))

--- a/packages/plugins/plugin-diff/src/__test__/diff-compute.spec.ts
+++ b/packages/plugins/plugin-diff/src/__test__/diff-compute.spec.ts
@@ -834,3 +834,139 @@ describe('computeDocDiff - per-block matching', () => {
     }
   })
 })
+
+describe('computeDocDiff - range option, per-block', () => {
+  it('sub-range produces per-block granular changes (not one merged change)', () => {
+    // Crown-jewel test for the per-block range path. Two adjacent list
+    // items inside the same bullet_list both change. Under the legacy
+    // single-step path the changeset library merges adjacent edits
+    // inside one container into a single change covering the whole ul;
+    // per-block must surface them as independent changes anchored to
+    // each li.
+    const oldDoc = doc(
+      p(text('header')),
+      ul(li(p(text('a'))), li(p(text('b'))), li(p(text('c'))))
+    )
+    const newDoc = doc(
+      p(text('header')),
+      ul(li(p(text('A'))), li(p(text('B'))), li(p(text('c'))))
+    )
+
+    // p('header') nodeSize = 8; ul nodeSize = 17 (3 li @ 5 each + 2).
+    // Range covers exactly the ul: from = 8, to = 25.
+    const changes = computeDocDiff(oldDoc, newDoc, {
+      range: { from: 8, to: 25 },
+    })
+
+    expect(changes.length).toBeGreaterThanOrEqual(2)
+    for (const change of changes) {
+      expect(change.fromA).toBeGreaterThanOrEqual(8)
+      expect(change.toA).toBeLessThanOrEqual(25)
+      expect(change.fromB).toBeGreaterThanOrEqual(8)
+      expect(change.toB).toBeLessThanOrEqual(25)
+      // No single change should span both modified list items (which
+      // would be the legacy merging behaviour). Each li is 5 wide.
+      expect(change.toA - change.fromA).toBeLessThan(10)
+    }
+  })
+
+  it('sub-range inside a list matches list-item boundaries', () => {
+    // Exercises a non-doc shared ancestor (the bullet_list).
+    const oldDoc = doc(ul(li(p(text('a'))), li(p(text('b'))), li(p(text('c')))))
+    const newDoc = doc(ul(li(p(text('a'))), li(p(text('X'))), li(p(text('c')))))
+
+    // ul content starts at pos 1; li1 [1,6), li2 [6,11), li3 [11,16).
+    // Range covers exactly li2.
+    const changes = computeDocDiff(oldDoc, newDoc, {
+      range: { from: 6, to: 11 },
+    })
+
+    expect(changes.length).toBeGreaterThan(0)
+    for (const change of changes) {
+      expect(change.fromA).toBeGreaterThanOrEqual(6)
+      expect(change.toA).toBeLessThanOrEqual(11)
+    }
+  })
+
+  it('sub-range exactly aligned with one unchanged block returns no changes', () => {
+    // Same shape as the legacy `sub-range excludes changes outside the
+    // range` test — must keep working under the per-block path.
+    const oldDoc = doc(p(text('AAA')), p(text('BBB')), p(text('CCC')))
+    const newDoc = doc(p(text('XXX')), p(text('BBB')), p(text('ZZZ')))
+
+    const changes = computeDocDiff(oldDoc, newDoc, {
+      range: { from: 5, to: 10 },
+    })
+    expect(changes).toHaveLength(0)
+  })
+
+  it('sub-range mid-textblock falls back to legacy', () => {
+    // Range endpoints inside a single paragraph → shared ancestor is a
+    // textblock → tryBuildRangeSubtree returns null → legacyDiff runs.
+    const oldDoc = doc(p(text('hello world')))
+    const newDoc = doc(p(text('hello brave world')))
+
+    const changes = computeDocDiff(oldDoc, newDoc, {
+      range: { from: 4, to: 8 },
+    })
+    expect(changes.length).toBeGreaterThan(0)
+  })
+
+  it('sub-range with sharedDepth divergence falls back to legacy', () => {
+    // Same numeric range resolves to a different sharedDepth in old vs
+    // new, so the per-block path bails out and legacyDiff handles it.
+    //
+    // In oldDoc (single paragraph 'hi there'), positions 3 and 4 both
+    // resolve inside the paragraph at depth 1, so sharedDepth = 1.
+    //
+    // In newDoc (two paragraphs 'hi' and ' there'), p('hi').nodeSize = 4,
+    // so position 3 is inside p1 at depth 1 but position 4 sits at the
+    // boundary between paragraphs at depth 0, so sharedDepth = 0.
+    const oldDoc = doc(p(text('hi there')))
+    const newDoc = doc(p(text('hi')), p(text(' there')))
+
+    const changes = computeDocDiff(oldDoc, newDoc, {
+      range: { from: 3, to: 4 },
+    })
+    expect(changes.length).toBeGreaterThan(0)
+  })
+
+  it('sub-range with asymmetric clamp falls back to legacy', () => {
+    // Raw `to` is past the end of the smaller doc but inside the larger
+    // one — clamps to different values per doc, so we hand off.
+    const oldDoc = doc(p(text('hi')))
+    const newDoc = doc(p(text('hi')), p(text('extra')))
+
+    const changes = computeDocDiff(oldDoc, newDoc, {
+      range: { from: 0, to: 50 },
+    })
+    expect(changes.length).toBeGreaterThan(0)
+  })
+
+  it('empty sub-range returns no changes', () => {
+    const oldDoc = doc(p(text('a')), p(text('b')))
+    const newDoc = doc(p(text('a')), p(text('B')))
+
+    const changes = computeDocDiff(oldDoc, newDoc, {
+      range: { from: 3, to: 3 },
+    })
+    expect(changes).toHaveLength(0)
+  })
+
+  it('sub-range changes are sorted and non-overlapping', () => {
+    // Two adjacent paragraphs change inside the range; the per-block
+    // path must keep its sorted, non-overlapping invariant for both
+    // axes (mergeBlockChanges depends on it).
+    const oldDoc = doc(p(text('A')), p(text('B')), p(text('C')), p(text('D')))
+    const newDoc = doc(p(text('A')), p(text('X')), p(text('Y')), p(text('D')))
+
+    const changes = computeDocDiff(oldDoc, newDoc, {
+      range: { from: 3, to: 9 },
+    })
+    expect(changes.length).toBeGreaterThanOrEqual(2)
+    for (let i = 1; i < changes.length; i++) {
+      expect(changes[i]!.fromA).toBeGreaterThanOrEqual(changes[i - 1]!.toA)
+      expect(changes[i]!.fromB).toBeGreaterThanOrEqual(changes[i - 1]!.toB)
+    }
+  })
+})

--- a/packages/plugins/plugin-diff/src/__test__/diff-compute.spec.ts
+++ b/packages/plugins/plugin-diff/src/__test__/diff-compute.spec.ts
@@ -402,8 +402,9 @@ describe('computeDocDiff - marks', () => {
 
 describe('computeDocDiff - range-limited', () => {
   it('detects changes only within specified range', () => {
+    // Same-size docs so a full-doc range is unambiguous in both.
     const oldDoc = doc(p(text('first')), p(text('second')), p(text('third')))
-    const newDoc = doc(p(text('first')), p(text('CHANGED')), p(text('third')))
+    const newDoc = doc(p(text('first')), p(text('SECOND')), p(text('third')))
     // Full diff should find changes
     const fullChanges = computeDocDiff(oldDoc, newDoc)
     expect(fullChanges.length).toBeGreaterThan(0)
@@ -900,21 +901,21 @@ describe('computeDocDiff - range option, per-block', () => {
     expect(changes).toHaveLength(0)
   })
 
-  it('sub-range mid-textblock falls back to legacy', () => {
+  it('sub-range mid-textblock throws RangeError', () => {
     // Range endpoints inside a single paragraph → shared ancestor is a
-    // textblock → tryBuildRangeSubtree returns null → legacyDiff runs.
+    // textblock → strict preconditions reject the range. Callers must
+    // widen the range to a block boundary.
     const oldDoc = doc(p(text('hello world')))
     const newDoc = doc(p(text('hello brave world')))
 
-    const changes = computeDocDiff(oldDoc, newDoc, {
-      range: { from: 4, to: 8 },
-    })
-    expect(changes.length).toBeGreaterThan(0)
+    expect(() =>
+      computeDocDiff(oldDoc, newDoc, { range: { from: 4, to: 8 } })
+    ).toThrow(RangeError)
   })
 
-  it('sub-range with sharedDepth divergence falls back to legacy', () => {
+  it('sub-range with sharedDepth divergence throws RangeError', () => {
     // Same numeric range resolves to a different sharedDepth in old vs
-    // new, so the per-block path bails out and legacyDiff handles it.
+    // new, so the strict preconditions reject the range.
     //
     // In oldDoc (single paragraph 'hi there'), positions 3 and 4 both
     // resolve inside the paragraph at depth 1, so sharedDepth = 1.
@@ -925,25 +926,27 @@ describe('computeDocDiff - range option, per-block', () => {
     const oldDoc = doc(p(text('hi there')))
     const newDoc = doc(p(text('hi')), p(text(' there')))
 
-    const changes = computeDocDiff(oldDoc, newDoc, {
-      range: { from: 3, to: 4 },
-    })
-    expect(changes.length).toBeGreaterThan(0)
+    expect(() =>
+      computeDocDiff(oldDoc, newDoc, { range: { from: 3, to: 4 } })
+    ).toThrow(RangeError)
   })
 
-  it('sub-range with asymmetric clamp falls back to legacy', () => {
-    // Raw `to` is past the end of the smaller doc but inside the larger
-    // one — clamps to different values per doc, so we hand off.
+  it('out-of-bounds range is silently clamped to the smaller doc', () => {
+    // Raw `to` is past the end of the smaller doc; the API clamps both
+    // endpoints to the smaller doc's size and runs per-block strictly
+    // within. The "extra" content of the larger doc is outside the
+    // (clamped) range and is correctly invisible to the diff.
     const oldDoc = doc(p(text('hi')))
     const newDoc = doc(p(text('hi')), p(text('extra')))
 
     const changes = computeDocDiff(oldDoc, newDoc, {
       range: { from: 0, to: 50 },
     })
-    expect(changes.length).toBeGreaterThan(0)
+    // Inside the clamped window [0, 4], both docs are identical.
+    expect(changes).toHaveLength(0)
   })
 
-  it('sub-range with mismatched ancestor start position falls back to legacy', () => {
+  it('sub-range with mismatched ancestor start position throws RangeError', () => {
     // Both docs have a bullet_list with the same children, but the
     // prefix paragraph differs in size, so the ul sits at different
     // absolute positions in the two docs. The same numeric range
@@ -953,11 +956,9 @@ describe('computeDocDiff - range option, per-block', () => {
     //   $oldFrom.start(1) = 11   (old ul.content starts at 11)
     //   $newFrom.start(1) = 16   (new ul.content starts at 16)
     //
-    // Without the absolute-start check in tryBuildRangeSubtree the cut
-    // would use mismatched local offsets and silently compare the wrong
-    // content. The check rejects the subtree extraction and we fall
-    // back to legacyDiff for correctness. This exercises the
-    // ancestor-chain mismatch branch of the precondition loop.
+    // Without the absolute-start check the cut would use mismatched
+    // local offsets and silently compare the wrong content; the strict
+    // preconditions throw a RangeError instead.
     const oldDoc = doc(
       p(text('xxxxxxxx')),
       ul(li(p(text('a'))), li(p(text('b'))))
@@ -967,10 +968,9 @@ describe('computeDocDiff - range option, per-block', () => {
       ul(li(p(text('a'))), li(p(text('b'))))
     )
 
-    const changes = computeDocDiff(oldDoc, newDoc, {
-      range: { from: 16, to: 21 },
-    })
-    expect(changes.length).toBeGreaterThan(0)
+    expect(() =>
+      computeDocDiff(oldDoc, newDoc, { range: { from: 16, to: 21 } })
+    ).toThrow(RangeError)
   })
 
   it('empty sub-range returns no changes', () => {
@@ -998,5 +998,72 @@ describe('computeDocDiff - range option, per-block', () => {
       expect(changes[i]!.fromA).toBeGreaterThanOrEqual(changes[i - 1]!.toA)
       expect(changes[i]!.fromB).toBeGreaterThanOrEqual(changes[i - 1]!.toB)
     }
+  })
+})
+
+// Schema with a container node (`blockquote`) carrying attrs, used for
+// the encoder/ignoreAttrs precondition tests below. The main test schema
+// has no container node with attrs, so we need a small bespoke schema
+// to exercise the ancestor-encoder check.
+describe('computeDocDiff - range option, ancestor attrs precondition', () => {
+  const blockquoteSchema = new Schema({
+    nodes: {
+      doc: { content: 'block+' },
+      paragraph: {
+        group: 'block',
+        content: 'inline*',
+        toDOM: () => ['p', 0],
+      },
+      text: { group: 'inline' },
+      blockquote: {
+        group: 'block',
+        content: 'block+',
+        attrs: { kind: { default: 'default' } },
+        toDOM: () => ['blockquote', 0],
+      },
+    },
+  })
+
+  const docBQ = (...children: any[]) =>
+    blockquoteSchema.node('doc', null, children)
+  const pBQ = (...content: any[]) =>
+    blockquoteSchema.node('paragraph', null, content)
+  const tBQ = (str: string) => blockquoteSchema.text(str)
+  const blockquote = (kind: string, ...content: any[]) =>
+    blockquoteSchema.node('blockquote', { kind }, content)
+
+  // Both docs share an outer blockquote whose `kind` attr differs but
+  // whose inner content is identical. Range covers the inner two
+  // paragraphs (boundary-aligned at the blockquote's content level).
+  // Position math:
+  //   p('a') and p('b') each nodeSize = 3, blockquote.content = 6,
+  //   blockquote.nodeSize = 8, doc.content.size = 8.
+  //   Range [1, 7] is inside blockquote.content at depth 1 in both docs.
+
+  it('honours ignoreAttrs on ancestor and runs the per-block path', () => {
+    // The ancestor blockquote's `kind` differs ('note' vs 'warning'),
+    // but ignoreAttrs tells the encoder to skip it. encodeNodeStart
+    // returns the same string for both ancestors → precondition passes
+    // → per-block runs → no changes (the inner paragraphs are equal).
+    const oldDoc = docBQ(blockquote('note', pBQ(tBQ('a')), pBQ(tBQ('b'))))
+    const newDoc = docBQ(blockquote('warning', pBQ(tBQ('a')), pBQ(tBQ('b'))))
+
+    const changes = computeDocDiff(oldDoc, newDoc, {
+      range: { from: 1, to: 7 },
+      ignoreAttrs: { blockquote: ['kind'] },
+    })
+    expect(changes).toHaveLength(0)
+  })
+
+  it('throws RangeError when a non-ignored ancestor attr differs', () => {
+    // Same docs as above but without ignoreAttrs. encodeNodeStart now
+    // returns different strings for the two blockquotes, so the
+    // precondition rejects the range.
+    const oldDoc = docBQ(blockquote('note', pBQ(tBQ('a')), pBQ(tBQ('b'))))
+    const newDoc = docBQ(blockquote('warning', pBQ(tBQ('a')), pBQ(tBQ('b'))))
+
+    expect(() =>
+      computeDocDiff(oldDoc, newDoc, { range: { from: 1, to: 7 } })
+    ).toThrow(RangeError)
   })
 })

--- a/packages/plugins/plugin-diff/src/diff-compute.ts
+++ b/packages/plugins/plugin-diff/src/diff-compute.ts
@@ -524,29 +524,137 @@ function isFullDocRange(
   return from <= 0 && to >= Math.max(oldSize, newSize)
 }
 
+/// A boundary-aligned subtree pair extracted from a sub-region range.
+/// Both cuts share the same `contentStart` because the path from doc root
+/// to the shared ancestor is identical (in type, attrs, and absolute
+/// position) in old and new docs.
+interface RangeSubtree {
+  oldCut: Node
+  newCut: Node
+  contentStart: number
+}
+
+/// Try to reduce a `[from, to)` sub-region into a pair of cut subtrees
+/// that the per-block LCS path can diff directly. Returns `null` (signal
+/// to fall back to `legacyDiff`) when any precondition fails:
+///
+/// - the docs disagree on `sharedDepth` for the range
+/// - any ancestor along the shared chain differs in type, attrs (via
+///   `encoder.encodeNodeStart`, so `ignoreAttrs` is honoured), or
+///   absolute starting position
+/// - the shared ancestor is a textblock (per-block can't subdivide
+///   inside a textblock — `legacyDiff` is the right tool there)
+/// - either endpoint lands mid-child instead of between siblings of the
+///   shared ancestor — `Fragment.cut` would mutate the boundary child's
+///   `nodeSize` and break absolute-position translation
+function tryBuildRangeSubtree(
+  oldDoc: Node,
+  newDoc: Node,
+  from: number,
+  to: number,
+  encoder: TokenEncoder<string | number>
+): RangeSubtree | null {
+  const $oldFrom = oldDoc.resolve(from)
+  const $oldTo = oldDoc.resolve(to)
+  const $newFrom = newDoc.resolve(from)
+  const $newTo = newDoc.resolve(to)
+
+  const sharedDepth = $oldFrom.sharedDepth(to)
+  if ($newFrom.sharedDepth(to) !== sharedDepth) return null
+
+  // Ancestor chain identity: the encoder's node-start token always
+  // begins with `node.type.name`, so a single equality check rejects
+  // type mismatches AND attr differences (and honours ignoreAttrs).
+  // Also require the same absolute start position at every depth up to
+  // sharedDepth — this guarantees the cut node's first child lines up
+  // at `from` in both docs.
+  for (let d = 0; d <= sharedDepth; d++) {
+    if (
+      encoder.encodeNodeStart($oldFrom.node(d)) !==
+      encoder.encodeNodeStart($newFrom.node(d))
+    )
+      return null
+    if ($oldFrom.start(d) !== $newFrom.start(d)) return null
+  }
+
+  const sharedOld = $oldFrom.node(sharedDepth)
+  if (sharedOld.isTextblock) return null
+
+  // Boundary alignment: both endpoints sit between children of the shared
+  // ancestor. ResolvedPos.depth equals sharedDepth precisely when the
+  // position is at a sibling boundary (not inside a child).
+  if ($oldFrom.depth !== sharedDepth || $oldTo.depth !== sharedDepth)
+    return null
+  if ($newFrom.depth !== sharedDepth || $newTo.depth !== sharedDepth)
+    return null
+
+  const sharedNew = $newFrom.node(sharedDepth)
+  const contentStart = $oldFrom.start(sharedDepth)
+  const localFrom = from - contentStart
+  const localTo = to - contentStart
+
+  // Boundary-aligned cut: Fragment.cut leaves child nodes untouched and
+  // only adjusts which children are included.
+  const oldCut = sharedOld.copy(sharedOld.content.cut(localFrom, localTo))
+  const newCut = sharedNew.copy(sharedNew.content.cut(localFrom, localTo))
+
+  // The cut node's first child has offset 0 in its own content but
+  // absolute position `from` in the original doc, so `from` is the right
+  // contentStart to feed back to diffChildrenLcs.
+  return { oldCut, newCut, contentStart: from }
+}
+
 /// Compute fine-grained changes between two ProseMirror documents.
-/// When `options.range` is provided, only the specified region is diffed.
 ///
 /// Uses per-block LCS matching (recursing into container nodes like
-/// bullet_list, blockquote, table). Falls back to a single-step diff
-/// when `options.range` actually restricts the diff to a sub-region of
-/// the document; a range that happens to cover the full document still
-/// takes the per-block path.
+/// bullet_list, blockquote, table). When `options.range` is provided and
+/// aligns to top-level child boundaries of a shared ancestor, the
+/// per-block path operates on a cut subtree so the result is just as
+/// fine-grained as the full-doc case. Mid-textblock ranges, structurally
+/// divergent docs, and asymmetric clamps fall back to a single-step diff.
 export function computeDocDiff(
   oldDoc: Node,
   newDoc: Node,
   options?: ComputeDocDiffOptions
 ): readonly Change[] {
   const encoder = createDiffEncoder(options?.ignoreAttrs)
+  const oldSize = oldDoc.content.size
+  const newSize = newDoc.content.size
 
-  // Sub-region range: use the legacy single-step path so the caller's
-  // boundary is honoured exactly. A range that covers the whole doc is
-  // treated as if no range were given.
-  if (!isFullDocRange(options, oldDoc.content.size, newDoc.content.size)) {
-    return legacyDiff(oldDoc, newDoc, options, encoder)
+  // Full-doc (or equivalent) → straight per-block path.
+  if (isFullDocRange(options, oldSize, newSize)) {
+    return diffChildrenLcs(oldDoc, newDoc, 0, 0, makeEnv(encoder))
   }
 
-  const env: LcsEnv = { encoder, sigCache: new WeakMap<Node, string>() }
-  // Top-level diff: parent content starts at position 0 in the doc.
-  return diffChildrenLcs(oldDoc, newDoc, 0, 0, env)
+  // Clamp exactly the way legacyDiff does so existing semantics stay
+  // identical when we eventually hand off to it.
+  const range = options!.range!
+  const minSize = Math.min(oldSize, newSize)
+  const from = Math.max(0, Math.min(range.from ?? 0, minSize))
+  const toOld = Math.max(from, Math.min(range.to ?? oldSize, oldSize))
+  const toNew = Math.max(from, Math.min(range.to ?? newSize, newSize))
+
+  // Asymmetric clamp → docs differ in size around the range. Hand off.
+  if (toOld !== toNew) return legacyDiff(oldDoc, newDoc, options, encoder)
+  const to = toOld
+
+  // Empty range → no changes.
+  if (from === to) return []
+
+  // Try to extract a boundary-aligned subtree on both sides; otherwise
+  // fall back to the legacy single-step path.
+  const subtree = tryBuildRangeSubtree(oldDoc, newDoc, from, to, encoder)
+  if (subtree == null) return legacyDiff(oldDoc, newDoc, options, encoder)
+
+  return diffChildrenLcs(
+    subtree.oldCut,
+    subtree.newCut,
+    subtree.contentStart,
+    subtree.contentStart,
+    makeEnv(encoder)
+  )
+}
+
+function makeEnv(encoder: TokenEncoder<string | number>): LcsEnv {
+  return { encoder, sigCache: new WeakMap<Node, string>() }
 }

--- a/packages/plugins/plugin-diff/src/diff-compute.ts
+++ b/packages/plugins/plugin-diff/src/diff-compute.ts
@@ -483,69 +483,6 @@ function attrsEqual(
   return encoder.encodeNodeStart(a) === encoder.encodeNodeStart(b)
 }
 
-/// A `range` option clamped against both doc sizes. `toOld` and `toNew`
-/// can differ when `range.to` is past the end of one doc but inside the
-/// other — that's the "asymmetric clamp" signal.
-interface ClampedRange {
-  from: number
-  toOld: number
-  toNew: number
-}
-
-/// Apply the legacy clamp semantics: `from` clamped against the smaller
-/// doc, `toOld` and `toNew` clamped per-doc, all monotonic with `from`.
-function clampRange(
-  range: ComputeDiffRange | undefined,
-  oldSize: number,
-  newSize: number
-): ClampedRange {
-  const minSize = Math.min(oldSize, newSize)
-  const from = Math.max(0, Math.min(range?.from ?? 0, minSize))
-  const toOld = Math.max(from, Math.min(range?.to ?? oldSize, oldSize))
-  const toNew = Math.max(from, Math.min(range?.to ?? newSize, newSize))
-  return { from, toOld, toNew }
-}
-
-/// Legacy single-step diff implementation. Used for the `range` option
-/// and as a fallback for large documents.
-function legacyDiff(
-  oldDoc: Node,
-  newDoc: Node,
-  options: ComputeDocDiffOptions | undefined,
-  encoder: TokenEncoder<string | number>
-): readonly Change[] {
-  const { from, toOld, toNew } = clampRange(
-    options?.range,
-    oldDoc.content.size,
-    newDoc.content.size
-  )
-
-  const step = new ReplaceStep(
-    from,
-    toOld,
-    new Slice(newDoc.content.cut(from, toNew), 0, 0)
-  )
-  const changeSet = ChangeSet.create(oldDoc, undefined, encoder).addSteps(
-    newDoc,
-    [step.getMap()],
-    null
-  )
-  return changeSet.changes
-}
-
-/// Returns true if `options.range` is effectively the full document.
-function isFullDocRange(
-  options: ComputeDocDiffOptions | undefined,
-  oldSize: number,
-  newSize: number
-): boolean {
-  const range = options?.range
-  if (!range) return true
-  const from = range.from ?? 0
-  const to = range.to ?? Math.max(oldSize, newSize)
-  return from <= 0 && to >= Math.max(oldSize, newSize)
-}
-
 /// A boundary-aligned subtree pair extracted from a sub-region range.
 ///
 /// `cutAbsStart` is the absolute doc position where the cut subtree's
@@ -560,33 +497,38 @@ interface RangeSubtree {
   cutAbsStart: number
 }
 
-/// Try to reduce a `[from, to)` sub-region into a pair of cut subtrees
-/// that the per-block LCS path can diff directly. Returns `null` (signal
-/// to fall back to `legacyDiff`) when any precondition fails:
+/// Reduce a `[from, to)` sub-region into a pair of cut subtrees that the
+/// per-block LCS path can diff directly. Throws `RangeError` when any
+/// precondition fails:
 ///
 /// - the docs disagree on `sharedDepth` for the range
 /// - any ancestor along the shared chain differs in type, attrs (via
 ///   `encoder.encodeNodeStart`, so `ignoreAttrs` is honoured), or
 ///   absolute starting position
 /// - the shared ancestor is a textblock (per-block can't subdivide
-///   inside a textblock — `legacyDiff` is the right tool there)
+///   inside a textblock — callers should widen the range to a block
+///   boundary instead)
 /// - either endpoint lands mid-child instead of between siblings of the
 ///   shared ancestor — `Fragment.cut` would mutate the boundary child's
 ///   `nodeSize` and break absolute-position translation
-function tryBuildRangeSubtree(
+function buildRangeSubtree(
   oldDoc: Node,
   newDoc: Node,
   from: number,
   to: number,
   encoder: TokenEncoder<string | number>
-): RangeSubtree | null {
+): RangeSubtree {
   const $oldFrom = oldDoc.resolve(from)
   const $oldTo = oldDoc.resolve(to)
   const $newFrom = newDoc.resolve(from)
   const $newTo = newDoc.resolve(to)
 
   const sharedDepth = $oldFrom.sharedDepth(to)
-  if ($newFrom.sharedDepth(to) !== sharedDepth) return null
+  if ($newFrom.sharedDepth(to) !== sharedDepth) {
+    throw new RangeError(
+      `computeDocDiff: range [${from}, ${to}) resolves to different sharedDepth in old and new docs`
+    )
+  }
 
   // Ancestor chain identity: the encoder's node-start token always
   // begins with `node.type.name`, so a single equality check rejects
@@ -598,21 +540,38 @@ function tryBuildRangeSubtree(
     if (
       encoder.encodeNodeStart($oldFrom.node(d)) !==
       encoder.encodeNodeStart($newFrom.node(d))
-    )
-      return null
-    if ($oldFrom.start(d) !== $newFrom.start(d)) return null
+    ) {
+      throw new RangeError(
+        `computeDocDiff: ancestor at depth ${d} differs in type or non-ignored attrs along the path to the shared ancestor`
+      )
+    }
+    if ($oldFrom.start(d) !== $newFrom.start(d)) {
+      throw new RangeError(
+        `computeDocDiff: ancestor at depth ${d} starts at different absolute positions in old and new docs (content before the range differs in size)`
+      )
+    }
   }
 
   const sharedOld = $oldFrom.node(sharedDepth)
-  if (sharedOld.isTextblock) return null
+  if (sharedOld.isTextblock) {
+    throw new RangeError(
+      `computeDocDiff: range [${from}, ${to}) lands inside a textblock; widen the range to a block boundary`
+    )
+  }
 
   // Boundary alignment: both endpoints sit between children of the shared
   // ancestor. ResolvedPos.depth equals sharedDepth precisely when the
   // position is at a sibling boundary (not inside a child).
-  if ($oldFrom.depth !== sharedDepth || $oldTo.depth !== sharedDepth)
-    return null
-  if ($newFrom.depth !== sharedDepth || $newTo.depth !== sharedDepth)
-    return null
+  if (
+    $oldFrom.depth !== sharedDepth ||
+    $oldTo.depth !== sharedDepth ||
+    $newFrom.depth !== sharedDepth ||
+    $newTo.depth !== sharedDepth
+  ) {
+    throw new RangeError(
+      `computeDocDiff: range [${from}, ${to}) endpoints must be aligned to top-level child boundaries of the shared ancestor`
+    )
+  }
 
   const sharedNew = $newFrom.node(sharedDepth)
   const ancestorContentStart = $oldFrom.start(sharedDepth)
@@ -626,56 +585,66 @@ function tryBuildRangeSubtree(
 
   // The cut node's first child has offset 0 inside the cut but absolute
   // position `from` in the original doc, so `from` is the contentStart
-  // we should hand back to diffChildrenLcs.
+  // we hand back to diffChildrenLcs.
   return { oldCut, newCut, cutAbsStart: from }
 }
 
 /// Compute fine-grained changes between two ProseMirror documents.
 ///
 /// Uses per-block LCS matching (recursing into container nodes like
-/// bullet_list, blockquote, table). When `options.range` is provided and
-/// aligns to top-level child boundaries of a shared ancestor, the
-/// per-block path operates on a cut subtree so the result is just as
-/// fine-grained as the full-doc case. Mid-textblock ranges, structurally
-/// divergent docs, and asymmetric clamps fall back to a single-step diff.
+/// bullet_list, blockquote, table). Without `options.range`, the entire
+/// document is diffed.
+///
+/// When `options.range` is provided, the diff is restricted to that
+/// region. The range must satisfy these preconditions or the call
+/// throws `RangeError`:
+///
+/// - **boundary-aligned**: both endpoints sit between siblings of a
+///   common (non-textblock) container ancestor — i.e. not inside a
+///   textblock and not in the middle of a child node
+/// - **structurally identical path**: the chain of ancestors leading to
+///   that shared container has the same node types, attrs (modulo
+///   `ignoreAttrs`), and absolute start positions in both docs
+///
+/// Out-of-bounds endpoints are clamped silently. An empty range returns
+/// no changes.
 export function computeDocDiff(
   oldDoc: Node,
   newDoc: Node,
   options?: ComputeDocDiffOptions
 ): readonly Change[] {
   const encoder = createDiffEncoder(options?.ignoreAttrs)
+  const env: LcsEnv = { encoder, sigCache: new WeakMap<Node, string>() }
   const oldSize = oldDoc.content.size
   const newSize = newDoc.content.size
 
-  // Full-doc (or equivalent) → straight per-block path.
-  if (isFullDocRange(options, oldSize, newSize)) {
-    return diffChildrenLcs(oldDoc, newDoc, 0, 0, makeEnv(encoder))
+  const range = options?.range
+  if (range == null) {
+    return diffChildrenLcs(oldDoc, newDoc, 0, 0, env)
   }
 
-  // Share the clamp with legacyDiff so semantics can't drift.
-  const { from, toOld, toNew } = clampRange(options?.range, oldSize, newSize)
-
-  // Asymmetric clamp → docs differ in size around the range. Hand off.
-  if (toOld !== toNew) return legacyDiff(oldDoc, newDoc, options, encoder)
-  const to = toOld
+  // Clamp the range to a valid window. Out-of-bounds endpoints are
+  // silently clamped against the smaller doc — once clamped, both old
+  // and new agree on the same `[from, to)` slice.
+  const minSize = Math.min(oldSize, newSize)
+  const from = Math.max(0, Math.min(range.from ?? 0, minSize))
+  const to = Math.max(from, Math.min(range.to ?? minSize, minSize))
 
   // Empty range → no changes.
   if (from === to) return []
 
-  // Try to extract a boundary-aligned subtree on both sides; otherwise
-  // fall back to the legacy single-step path.
-  const subtree = tryBuildRangeSubtree(oldDoc, newDoc, from, to, encoder)
-  if (subtree == null) return legacyDiff(oldDoc, newDoc, options, encoder)
+  // Range that covers the whole common window of two same-sized docs is
+  // equivalent to no range at all.
+  if (from === 0 && to === minSize && oldSize === newSize) {
+    return diffChildrenLcs(oldDoc, newDoc, 0, 0, env)
+  }
 
+  const subtree = buildRangeSubtree(oldDoc, newDoc, from, to, encoder)
   return diffChildrenLcs(
     subtree.oldCut,
     subtree.newCut,
     subtree.cutAbsStart,
     subtree.cutAbsStart,
-    makeEnv(encoder)
+    env
   )
-}
-
-function makeEnv(encoder: TokenEncoder<string | number>): LcsEnv {
-  return { encoder, sigCache: new WeakMap<Node, string>() }
 }

--- a/packages/plugins/plugin-diff/src/diff-compute.ts
+++ b/packages/plugins/plugin-diff/src/diff-compute.ts
@@ -483,6 +483,29 @@ function attrsEqual(
   return encoder.encodeNodeStart(a) === encoder.encodeNodeStart(b)
 }
 
+/// A `range` option clamped against both doc sizes. `toOld` and `toNew`
+/// can differ when `range.to` is past the end of one doc but inside the
+/// other — that's the "asymmetric clamp" signal.
+interface ClampedRange {
+  from: number
+  toOld: number
+  toNew: number
+}
+
+/// Apply the legacy clamp semantics: `from` clamped against the smaller
+/// doc, `toOld` and `toNew` clamped per-doc, all monotonic with `from`.
+function clampRange(
+  range: ComputeDiffRange | undefined,
+  oldSize: number,
+  newSize: number
+): ClampedRange {
+  const minSize = Math.min(oldSize, newSize)
+  const from = Math.max(0, Math.min(range?.from ?? 0, minSize))
+  const toOld = Math.max(from, Math.min(range?.to ?? oldSize, oldSize))
+  const toNew = Math.max(from, Math.min(range?.to ?? newSize, newSize))
+  return { from, toOld, toNew }
+}
+
 /// Legacy single-step diff implementation. Used for the `range` option
 /// and as a fallback for large documents.
 function legacyDiff(
@@ -491,12 +514,11 @@ function legacyDiff(
   options: ComputeDocDiffOptions | undefined,
   encoder: TokenEncoder<string | number>
 ): readonly Change[] {
-  const oldSize = oldDoc.content.size
-  const newSize = newDoc.content.size
-  const minSize = Math.min(oldSize, newSize)
-  const from = Math.max(0, Math.min(options?.range?.from ?? 0, minSize))
-  const toOld = Math.max(from, Math.min(options?.range?.to ?? oldSize, oldSize))
-  const toNew = Math.max(from, Math.min(options?.range?.to ?? newSize, newSize))
+  const { from, toOld, toNew } = clampRange(
+    options?.range,
+    oldDoc.content.size,
+    newDoc.content.size
+  )
 
   const step = new ReplaceStep(
     from,
@@ -630,13 +652,8 @@ export function computeDocDiff(
     return diffChildrenLcs(oldDoc, newDoc, 0, 0, makeEnv(encoder))
   }
 
-  // Clamp exactly the way legacyDiff does so existing semantics stay
-  // identical when we eventually hand off to it.
-  const range = options!.range!
-  const minSize = Math.min(oldSize, newSize)
-  const from = Math.max(0, Math.min(range.from ?? 0, minSize))
-  const toOld = Math.max(from, Math.min(range.to ?? oldSize, oldSize))
-  const toNew = Math.max(from, Math.min(range.to ?? newSize, newSize))
+  // Share the clamp with legacyDiff so semantics can't drift.
+  const { from, toOld, toNew } = clampRange(options?.range, oldSize, newSize)
 
   // Asymmetric clamp → docs differ in size around the range. Hand off.
   if (toOld !== toNew) return legacyDiff(oldDoc, newDoc, options, encoder)

--- a/packages/plugins/plugin-diff/src/diff-compute.ts
+++ b/packages/plugins/plugin-diff/src/diff-compute.ts
@@ -525,13 +525,17 @@ function isFullDocRange(
 }
 
 /// A boundary-aligned subtree pair extracted from a sub-region range.
-/// Both cuts share the same `contentStart` because the path from doc root
-/// to the shared ancestor is identical (in type, attrs, and absolute
-/// position) in old and new docs.
+///
+/// `cutAbsStart` is the absolute doc position where the cut subtree's
+/// first child sits in the original doc. It equals the range's `from`,
+/// and is the same in both docs because the precondition loop verifies
+/// the path from the doc root to the shared ancestor has the same
+/// absolute starts on both sides. It's the value to pass as
+/// `contentStart` to `diffChildrenLcs`.
 interface RangeSubtree {
   oldCut: Node
   newCut: Node
-  contentStart: number
+  cutAbsStart: number
 }
 
 /// Try to reduce a `[from, to)` sub-region into a pair of cut subtrees
@@ -589,19 +593,19 @@ function tryBuildRangeSubtree(
     return null
 
   const sharedNew = $newFrom.node(sharedDepth)
-  const contentStart = $oldFrom.start(sharedDepth)
-  const localFrom = from - contentStart
-  const localTo = to - contentStart
+  const ancestorContentStart = $oldFrom.start(sharedDepth)
+  const localFrom = from - ancestorContentStart
+  const localTo = to - ancestorContentStart
 
   // Boundary-aligned cut: Fragment.cut leaves child nodes untouched and
   // only adjusts which children are included.
   const oldCut = sharedOld.copy(sharedOld.content.cut(localFrom, localTo))
   const newCut = sharedNew.copy(sharedNew.content.cut(localFrom, localTo))
 
-  // The cut node's first child has offset 0 in its own content but
-  // absolute position `from` in the original doc, so `from` is the right
-  // contentStart to feed back to diffChildrenLcs.
-  return { oldCut, newCut, contentStart: from }
+  // The cut node's first child has offset 0 inside the cut but absolute
+  // position `from` in the original doc, so `from` is the contentStart
+  // we should hand back to diffChildrenLcs.
+  return { oldCut, newCut, cutAbsStart: from }
 }
 
 /// Compute fine-grained changes between two ProseMirror documents.
@@ -649,8 +653,8 @@ export function computeDocDiff(
   return diffChildrenLcs(
     subtree.oldCut,
     subtree.newCut,
-    subtree.contentStart,
-    subtree.contentStart,
+    subtree.cutAbsStart,
+    subtree.cutAbsStart,
     makeEnv(encoder)
   )
 }

--- a/packages/plugins/plugin-diff/src/diff-compute.ts
+++ b/packages/plugins/plugin-diff/src/diff-compute.ts
@@ -569,7 +569,7 @@ function buildRangeSubtree(
     $newTo.depth !== sharedDepth
   ) {
     throw new RangeError(
-      `computeDocDiff: range [${from}, ${to}) endpoints must be aligned to top-level child boundaries of the shared ancestor`
+      `computeDocDiff: range [${from}, ${to}) endpoints must be aligned to child boundaries of the shared ancestor`
     )
   }
 


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

`computeDocDiff`'s `options.range` path used to fall back to a single-step `ReplaceStep` + `ChangeSet`, which collapses adjacent edits inside the same container into one merged change. AI workflows that scope a diff to a user selection ("rewrite this paragraph", "translate these list items", "improve this section") need the same per-change granularity the full-doc path already gives — otherwise the diff-review UI can't surface the individual edits.

This PR rewires the range path to use the per-block LCS algorithm shipped in #2328 for the full-doc case. When `range` is provided, we resolve both endpoints in old and new docs, walk up to their shared ancestor, verify the path matches (type, attrs via the encoder so `ignoreAttrs` is honoured, and absolute start position at every depth), require the endpoints to be boundary-aligned at the shared ancestor's child level, then cut both ancestors to just the in-range content and feed the cut subtrees to the existing `diffChildrenLcs`. Positions come back as absolute doc coordinates so downstream consumers (`mergeBlockChanges`, the decoration plugin, `acceptDiffRangeCmd`) need no changes.

The diff plugin is unreleased and no production caller passes the `range` option, so this PR also takes the opportunity to delete `legacyDiff` entirely (along with `clampRange` and `isFullDocRange`) and replace its fallback role with strict preconditions. The `range` option now has a clear contract:

- **boundary-aligned**: both endpoints sit between siblings of a common (non-textblock) container ancestor — no mid-textblock, no mid-child positions
- **structurally identical path**: the chain of ancestors leading to the shared container has the same node types, attrs (modulo `ignoreAttrs`), and absolute start positions in both docs
- **out-of-bounds endpoints are clamped silently** to the smaller doc; **empty ranges return `[]`**
- **anything else throws `RangeError`** with a descriptive message — no silent fallback to a coarser diff

Net result: the production code surface for diff-compute drops by ~50 lines, the contract is explicit, and the per-change granularity is uniform between the full-doc and sub-range paths.

The streaming plugin and the diff plugin don't pass `range` at all, so this is a transparent upgrade for them. The next AI rewrite UX feature will exercise the new path for real.

## How did you test this change?

- Added a new `describe('computeDocDiff - range option, per-block', ...)` block in `diff-compute.spec.ts` covering the per-block granularity, the four `RangeError` paths (mid-textblock, sharedDepth divergence, ancestor start mismatch, mid-child boundary), the out-of-bounds clamp, the empty-range short-circuit, the boundary-aligned cut on a non-doc shared ancestor (a `bullet_list`), and the sorted/non-overlapping invariant.
- Added a `describe('computeDocDiff - range option, ancestor attrs precondition', ...)` block with a small bespoke `blockquote` schema (since the main test schema has no container node with attrs) covering the encoder/`ignoreAttrs` dimension: ignored ancestor attrs allow the per-block path to run; non-ignored attrs throw `RangeError`.
- Verified the existing `describe('computeDocDiff - range-limited', ...)` block continues to pass under the new strict semantics.
- Verified each new precondition test catches a real regression by stashing the corresponding check in `buildRangeSubtree` and watching the test fail.
- Ran the vitest suites in `packages/plugins/plugin-diff`, `packages/plugins/plugin-streaming`, and `packages/components`.
- Ran the Playwright suite in `e2e`.