### PR TITLE
fix(components): allow foreignObject in code block preview for Mermaid v11+ flowcharts

### DIFF
--- a/.changeset/fix-dompurify-foreignobject.md
+++ b/.changeset/fix-dompurify-foreignobject.md
@@ -1,5 +1,0 @@
----
-"@milkdown/components": patch
----
-
-Fix code block preview stripping Mermaid v11+ flowchart labels by allowing foreignObject in DOMPurify sanitization

--- a/.changeset/fix-dompurify-foreignobject.md
+++ b/.changeset/fix-dompurify-foreignobject.md
@@ -1,0 +1,5 @@
+---
+"@milkdown/components": patch
+---
+
+Fix code block preview stripping Mermaid v11+ flowchart labels by allowing foreignObject in DOMPurify sanitization

--- a/packages/components/src/code-block/view/components/preview-panel.tsx
+++ b/packages/components/src/code-block/view/components/preview-panel.tsx
@@ -10,26 +10,36 @@ keepAlive(h, Fragment)
 const SVG_NAMESPACE = 'http://www.w3.org/2000/svg'
 
 /**
- * Creates a DOMPurify instance that allows foreignObject only inside SVG.
- * foreignObject is needed for Mermaid v11+ flowchart labels, but is a known
- * mXSS vector (CVE-2020-26870) when allowed outside SVG context.
+ * Creates a sanitizer that allows foreignObject only inside SVG context.
+ *
+ * Mermaid v11+ uses foreignObject for flowchart node labels, but foreignObject
+ * is a known mXSS vector (CVE-2020-26870) outside SVG context. The strategy:
+ *   1. ADD_TAGS allows foreignObject to survive DOMPurify's initial filtering
+ *   2. The uponSanitizeElement hook removes it if NOT inside an SVG element
+ *   3. HTML_INTEGRATION_POINTS lets its HTML children parse correctly
  */
 function createSvgAwareSanitizer() {
   const purify = DOMPurify()
+
+  const config = {
+    ADD_TAGS: ['foreignObject'],
+    ADD_ATTR: ['xmlns'],
+    HTML_INTEGRATION_POINTS: { foreignobject: true },
+  }
 
   purify.addHook('uponSanitizeElement', (node, data) => {
     if (data.tagName === 'foreignobject') {
       const parent = node.parentElement
       if (!parent || parent.namespaceURI !== SVG_NAMESPACE) {
-        node.remove()
+        node.parentNode?.removeChild(node)
       }
     }
   })
 
-  return purify
+  return (dirty: string | Node) => purify.sanitize(dirty, config)
 }
 
-const svgPurify = createSvgAwareSanitizer()
+const sanitizeSvg = createSvgAwareSanitizer()
 
 type PreviewPanelProps = Pick<
   CodeBlockProps,
@@ -80,11 +90,7 @@ export const PreviewPanel = defineComponent<PreviewPanelProps>({
         typeof previewContent === 'string' ||
         previewContent instanceof Element
       ) {
-        previewContainer.innerHTML = svgPurify.sanitize(previewContent, {
-          ADD_TAGS: ['foreignObject'],
-          ADD_ATTR: ['xmlns'],
-          HTML_INTEGRATION_POINTS: { foreignobject: true },
-        })
+        previewContainer.innerHTML = sanitizeSvg(previewContent)
       }
     })
 

--- a/packages/components/src/code-block/view/components/preview-panel.tsx
+++ b/packages/components/src/code-block/view/components/preview-panel.tsx
@@ -83,6 +83,7 @@ export const PreviewPanel = defineComponent<PreviewPanelProps>({
         previewContainer.innerHTML = svgPurify.sanitize(previewContent, {
           ADD_TAGS: ['foreignObject'],
           ADD_ATTR: ['xmlns'],
+          HTML_INTEGRATION_POINTS: { foreignobject: true },
         })
       }
     })

--- a/packages/components/src/code-block/view/components/preview-panel.tsx
+++ b/packages/components/src/code-block/view/components/preview-panel.tsx
@@ -56,7 +56,7 @@ export const PreviewPanel = defineComponent<PreviewPanelProps>({
         typeof previewContent === 'string' ||
         previewContent instanceof Element
       ) {
-        previewContainer.innerHTML = DOMPurify.sanitize(previewContent)
+        previewContainer.innerHTML = DOMPurify.sanitize(previewContent, { ADD_TAGS: ['foreignObject'], ADD_ATTR: ['xmlns'] })
       }
     })
 

--- a/packages/components/src/code-block/view/components/preview-panel.tsx
+++ b/packages/components/src/code-block/view/components/preview-panel.tsx
@@ -7,6 +7,30 @@ import { keepAlive } from '../../../__internal__/keep-alive'
 
 keepAlive(h, Fragment)
 
+const SVG_NAMESPACE = 'http://www.w3.org/2000/svg'
+
+/**
+ * Creates a DOMPurify instance that allows foreignObject only inside SVG.
+ * foreignObject is needed for Mermaid v11+ flowchart labels, but is a known
+ * mXSS vector (CVE-2020-26870) when allowed outside SVG context.
+ */
+function createSvgAwareSanitizer() {
+  const purify = DOMPurify()
+
+  purify.addHook('uponSanitizeElement', (node, data) => {
+    if (data.tagName === 'foreignobject') {
+      const parent = node.parentElement
+      if (!parent || parent.namespaceURI !== SVG_NAMESPACE) {
+        node.remove()
+      }
+    }
+  })
+
+  return purify
+}
+
+const svgPurify = createSvgAwareSanitizer()
+
 type PreviewPanelProps = Pick<
   CodeBlockProps,
   'text' | 'language' | 'config'
@@ -56,7 +80,10 @@ export const PreviewPanel = defineComponent<PreviewPanelProps>({
         typeof previewContent === 'string' ||
         previewContent instanceof Element
       ) {
-        previewContainer.innerHTML = DOMPurify.sanitize(previewContent, { ADD_TAGS: ['foreignObject'], ADD_ATTR: ['xmlns'] })
+        previewContainer.innerHTML = svgPurify.sanitize(previewContent, {
+          ADD_TAGS: ['foreignObject'],
+          ADD_ATTR: ['xmlns'],
+        })
       }
     })
 


### PR DESCRIPTION
…d v11+ flowcharts

DOMPurify.sanitize() with default config strips foreignObject elements from SVG. Mermaid v11+ uses foreignObject for flowchart node labels, causing all text to disappear in the code block preview.

- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Mermaid v11+ renders flowchart node labels using `<foreignObject>` elements inside SVG. The `PreviewPanel` component sanitizes preview content with `DOMPurify.sanitize()` using default configuration, which strips `<foreignObject>` elements. This causes **all flowchart node labels to disappear** — boxes and arrows render correctly, but all text inside nodes is missing.

`mermaid.render()` produces valid SVG containing:

```xml
<foreignObject width="83" height="24">
  <div xmlns="http://www.w3.org/1999/xhtml">
    <span class="nodeLabel"><p>Hello World</p></span>
  </div>
</foreignObject>