### PR TITLE
refactor: remove broken config options from diff and streaming plugins

### DIFF
--- a/docs/api/crepe.md
+++ b/docs/api/crepe.md
@@ -623,7 +623,7 @@ const crepe = new Crepe({
         // Yield markdown tokens from your LLM
       },
       diffReviewOnEnd: true,
-      diff: { lockOnReview: true },
+      diff: { acceptLabel: 'Yes', rejectLabel: 'No' },
       streaming: { throttleMs: 150 },
     } satisfies AIFeatureConfig,
   },

--- a/docs/api/plugin-diff.md
+++ b/docs/api/plugin-diff.md
@@ -87,7 +87,6 @@ Editor.make()
   .config((ctx) => {
     ctx.update(diffConfig.key, (prev) => ({
       ...prev,
-      lockOnReview: false, // Allow editing during diff review (default: true)
       ignoreAttrs: { heading: ['id'] }, // Ignore these attrs when diffing (default: { heading: ['id'] })
     }))
   })
@@ -107,7 +106,6 @@ Editor.make()
   .config((ctx) => {
     ctx.update(diffComponentConfig.key, (prev) => ({
       ...prev,
-      classPrefix: 'my-diff', // CSS class prefix (default: 'milkdown-diff')
       acceptLabel: 'Apply', // Accept button text (default: 'Accept')
       rejectLabel: 'Discard', // Reject button text (default: 'Reject')
       customBlockTypes: [

--- a/docs/api/plugin-streaming.md
+++ b/docs/api/plugin-streaming.md
@@ -137,7 +137,6 @@ editor.config((ctx) => {
   ctx.update(streamingConfig.key, (prev) => ({
     ...prev,
     throttleMs: 100, // Flush interval in ms (default: 100)
-    lockDuringStreaming: true, // Block user edits during streaming (default: true)
     scrollFollow: true, // Auto-scroll to follow content (default: true)
     diffReviewOnEnd: false, // Enter diff review on end (default: false)
   }))

--- a/packages/components/src/diff/config.ts
+++ b/packages/components/src/diff/config.ts
@@ -3,7 +3,6 @@ import { $ctx } from '@milkdown/utils'
 import { withMeta } from '../__internal__/meta'
 
 export interface DiffComponentConfig {
-  classPrefix: string
   acceptLabel: string
   rejectLabel: string
   /// Node type names that use custom node views where inline decorations
@@ -13,7 +12,6 @@ export interface DiffComponentConfig {
 }
 
 const defaultConfig: DiffComponentConfig = {
-  classPrefix: 'milkdown-diff',
   acceptLabel: 'Accept',
   rejectLabel: 'Reject',
   customBlockTypes: [],

--- a/packages/components/src/diff/config.ts
+++ b/packages/components/src/diff/config.ts
@@ -2,6 +2,10 @@ import { $ctx } from '@milkdown/utils'
 
 import { withMeta } from '../__internal__/meta'
 
+/// The CSS class prefix used by all diff decorations. Hardcoded because
+/// all Crepe themes rely on `milkdown-diff-*` selectors.
+export const DIFF_CLASS_PREFIX = 'milkdown-diff'
+
 export interface DiffComponentConfig {
   acceptLabel: string
   rejectLabel: string

--- a/packages/components/src/diff/diff-decoration-plugin.ts
+++ b/packages/components/src/diff/diff-decoration-plugin.ts
@@ -73,13 +73,14 @@ withMeta(diffDecorationPlugin, {
 // Decoration builders
 // ---------------------------------------------------------------------------
 
+const CLASS_PREFIX = 'milkdown-diff'
+
 interface CrossBoundaryOptions {
   doc: Node
   newDoc: Node
   segments: ChangeSegment[]
   change: MergedChange
   changeIndex: number
-  classPrefix: string
   commands: CommandManager
   acceptLabel: string
   rejectLabel: string
@@ -93,7 +94,6 @@ function addCrossBoundaryDecorations({
   segments,
   change,
   changeIndex,
-  classPrefix,
   commands,
   acceptLabel,
   rejectLabel,
@@ -106,17 +106,11 @@ function addCrossBoundaryDecorations({
 
     if (segDeletion) {
       if (seg.isBlock) {
-        addBlockDeletionDecorations(
-          doc,
-          seg.fromA,
-          seg.toA,
-          classPrefix,
-          decorations
-        )
+        addBlockDeletionDecorations(doc, seg.fromA, seg.toA, decorations)
       } else {
         decorations.push(
           Decoration.inline(seg.fromA, seg.toA, {
-            class: `${classPrefix}-removed`,
+            class: `${CLASS_PREFIX}-removed`,
           })
         )
       }
@@ -128,7 +122,7 @@ function addCrossBoundaryDecorations({
         : segDeletion
           ? seg.toA
           : seg.fromA
-      const widget = createInsertedWidget(newDoc, seg, classPrefix, seg.isBlock)
+      const widget = createInsertedWidget(newDoc, seg, seg.isBlock)
       decorations.push(
         Decoration.widget(widgetPos, widget, {
           side: -1,
@@ -148,7 +142,6 @@ function addCrossBoundaryDecorations({
   const controlsPos = snapToBlockBoundary(doc, lastSegEnd)
   const controls = createControlsWidget({
     commands,
-    classPrefix,
     isBlockLevel: true,
     change,
     acceptLabel,
@@ -167,7 +160,6 @@ function buildDecorations(
   doc: Node,
   diffState: DiffState,
   config: {
-    classPrefix: string
     customBlockTypes: string[]
     acceptLabel: string
     rejectLabel: string
@@ -175,7 +167,6 @@ function buildDecorations(
 ): DecorationSet {
   const decorations: Decoration[] = []
   const commands = ctx.get(commandsCtx)
-  const classPrefix = config.classPrefix
   const customBlockTypes = new Set(config.customBlockTypes)
   const pending = getPendingChanges(diffState)
   const mergedChanges = mergeBlockChanges(
@@ -234,7 +225,6 @@ function buildDecorations(
           segments,
           change,
           changeIndex: i,
-          classPrefix,
           commands,
           acceptLabel: config.acceptLabel,
           rejectLabel: config.rejectLabel,
@@ -247,17 +237,11 @@ function buildDecorations(
     // Non-split path: render as a single change
     if (isDeletion) {
       if (change.isCustomBlock || isBlockLevel) {
-        addBlockDeletionDecorations(
-          doc,
-          change.fromA,
-          change.toA,
-          classPrefix,
-          decorations
-        )
+        addBlockDeletionDecorations(doc, change.fromA, change.toA, decorations)
       } else {
         decorations.push(
           Decoration.inline(change.fromA, change.toA, {
-            class: `${classPrefix}-removed`,
+            class: `${CLASS_PREFIX}-removed`,
           })
         )
       }
@@ -272,7 +256,6 @@ function buildDecorations(
       const widget = createInsertedWidget(
         diffState.newDoc,
         change,
-        classPrefix,
         isBlockLevel
       )
       decorations.push(
@@ -282,7 +265,6 @@ function buildDecorations(
 
     const controls = createControlsWidget({
       commands,
-      classPrefix,
       isBlockLevel,
       change,
       acceptLabel: config.acceptLabel,
@@ -306,13 +288,12 @@ function buildDecorations(
 function createInsertedWidget(
   newDoc: Node,
   change: { fromB: number; toB: number },
-  classPrefix: string,
   isBlockLevel: boolean
 ): HTMLElement {
   const dom = document.createElement(isBlockLevel ? 'div' : 'span')
-  dom.className = `${classPrefix}-added`
+  dom.className = `${CLASS_PREFIX}-added`
   dom.contentEditable = 'false'
-  if (isBlockLevel) dom.classList.add(`${classPrefix}-added-block`)
+  if (isBlockLevel) dom.classList.add(`${CLASS_PREFIX}-added-block`)
 
   const serializer = DOMSerializer.fromSchema(newDoc.type.schema)
 
@@ -354,7 +335,6 @@ function createInsertedWidget(
 
 interface ControlsWidgetOptions {
   commands: CommandManager
-  classPrefix: string
   isBlockLevel: boolean
   change: MergedChange
   acceptLabel: string
@@ -363,16 +343,15 @@ interface ControlsWidgetOptions {
 
 function createControlsWidget({
   commands,
-  classPrefix,
   isBlockLevel,
   change,
   acceptLabel,
   rejectLabel,
 }: ControlsWidgetOptions): HTMLElement {
   const dom = document.createElement(isBlockLevel ? 'div' : 'span')
-  dom.className = `${classPrefix}-controls`
+  dom.className = `${CLASS_PREFIX}-controls`
   dom.contentEditable = 'false'
-  if (isBlockLevel) dom.classList.add(`${classPrefix}-controls-block`)
+  if (isBlockLevel) dom.classList.add(`${CLASS_PREFIX}-controls-block`)
 
   const handler = (action: 'accept' | 'reject') => (e: Event) => {
     e.preventDefault()
@@ -391,12 +370,12 @@ function createControlsWidget({
   }
 
   const acceptBtn = document.createElement('button')
-  acceptBtn.className = `${classPrefix}-accept`
+  acceptBtn.className = `${CLASS_PREFIX}-accept`
   acceptBtn.textContent = acceptLabel
   acceptBtn.addEventListener('click', handler('accept'))
 
   const rejectBtn = document.createElement('button')
-  rejectBtn.className = `${classPrefix}-reject`
+  rejectBtn.className = `${CLASS_PREFIX}-reject`
   rejectBtn.textContent = rejectLabel
   rejectBtn.addEventListener('click', handler('reject'))
 

--- a/packages/components/src/diff/diff-decoration-plugin.ts
+++ b/packages/components/src/diff/diff-decoration-plugin.ts
@@ -18,7 +18,10 @@ import { $prose } from '@milkdown/utils'
 import type { ChangeSegment, MergedChange } from './merge-changes'
 
 import { withMeta } from '../__internal__/meta'
-import { diffComponentConfig } from './config'
+import {
+  DIFF_CLASS_PREFIX as CLASS_PREFIX,
+  diffComponentConfig,
+} from './config'
 import {
   addBlockDeletionDecorations,
   collectTopLevelNodes,
@@ -72,8 +75,6 @@ withMeta(diffDecorationPlugin, {
 // ---------------------------------------------------------------------------
 // Decoration builders
 // ---------------------------------------------------------------------------
-
-const CLASS_PREFIX = 'milkdown-diff'
 
 interface CrossBoundaryOptions {
   doc: Node

--- a/packages/components/src/diff/doc-utils.ts
+++ b/packages/components/src/diff/doc-utils.ts
@@ -127,7 +127,6 @@ export function addBlockDeletionDecorations(
   doc: Node,
   from: number,
   to: number,
-  classPrefix: string,
   decorations: Decoration[]
 ): void {
   forEachTopLevelNodeInRange(doc, from, to, (node, start, end) => {
@@ -141,7 +140,7 @@ export function addBlockDeletionDecorations(
 
     decorations.push(
       Decoration.node(start, end, {
-        class: `${classPrefix}-removed-block`,
+        class: 'milkdown-diff-removed-block',
       })
     )
   })

--- a/packages/components/src/diff/doc-utils.ts
+++ b/packages/components/src/diff/doc-utils.ts
@@ -2,6 +2,8 @@ import type { Node } from '@milkdown/prose/model'
 
 import { Decoration } from '@milkdown/prose/view'
 
+import { DIFF_CLASS_PREFIX } from './config'
+
 /// Check if a position range in a doc crosses a top-level block boundary.
 export function isBlockSpanning(doc: Node, from: number, to: number): boolean {
   if (from === to) return false
@@ -140,7 +142,7 @@ export function addBlockDeletionDecorations(
 
     decorations.push(
       Decoration.node(start, end, {
-        class: 'milkdown-diff-removed-block',
+        class: `${DIFF_CLASS_PREFIX}-removed-block`,
       })
     )
   })

--- a/packages/crepe/src/feature/ai/commands.ts
+++ b/packages/crepe/src/feature/ai/commands.ts
@@ -117,7 +117,7 @@ export const runAICmd = $command('RunAI', (ctx) => {
     if (!config.provider) return false
 
     // Reject if a session is already running, streaming is active, or
-    // diff review is active (lockOnReview blocks non-diff transactions,
+    // diff review is active (the diff plugin blocks non-diff transactions,
     // so streaming flushes would be silently rejected).
     const session = ctx.get(aiSessionCtx.key)
     if (session.abortController) return false

--- a/packages/crepe/src/feature/ai/index.ts
+++ b/packages/crepe/src/feature/ai/index.ts
@@ -37,12 +37,9 @@ export const ai: DefineFeature<AIFeatureConfig> = (editor, config) => {
     .config((ctx) => {
       ctx.update(diffConfig.key, (prev) => ({
         ...prev,
-        ...(diffCfg.lockOnReview !== undefined
-          ? { lockOnReview: diffCfg.lockOnReview }
-          : {}),
         ignoreAttrs: diffCfg.ignoreAttrs ?? CREPE_IGNORE_ATTRS,
       }))
-      const { lockOnReview: _, ignoreAttrs: __, ...componentConfig } = diffCfg
+      const { ignoreAttrs: _, ...componentConfig } = diffCfg
       ctx.update(diffComponentConfig.key, (prev) => ({
         ...prev,
         customBlockTypes:

--- a/packages/crepe/src/feature/ai/types.ts
+++ b/packages/crepe/src/feature/ai/types.ts
@@ -15,10 +15,8 @@ export type AIProvider = (
   signal: AbortSignal
 ) => AsyncIterable<string>
 
-/// Diff-related config options passed through to `@milkdown/plugin-diff`.
+/// Diff-related config options passed through to the diff plugin and component.
 export interface AIDiffConfig {
-  lockOnReview?: boolean
-  classPrefix?: string
   acceptLabel?: string
   rejectLabel?: string
   customBlockTypes?: string[]

--- a/packages/plugins/plugin-diff/src/diff-config.ts
+++ b/packages/plugins/plugin-diff/src/diff-config.ts
@@ -6,7 +6,7 @@ import { withMeta } from './__internal__/with-meta'
 
 /// The configuration context for the diff plugin.
 export const diffConfig = $ctx<DiffConfig, 'diffConfig'>(
-  { lockOnReview: true, ignoreAttrs: { heading: ['id'] } },
+  { ignoreAttrs: { heading: ['id'] } },
   'diffConfig'
 )
 

--- a/packages/plugins/plugin-diff/src/diff-plugin.ts
+++ b/packages/plugins/plugin-diff/src/diff-plugin.ts
@@ -128,8 +128,6 @@ export const diffPlugin = $prose((ctx) => {
       },
     },
     filterTransaction(tr, editorState) {
-      if (!config.lockOnReview) return true
-
       const diffState = diffPluginKey.getState(editorState)
       if (!diffState?.active) return true
 

--- a/packages/plugins/plugin-diff/src/types.ts
+++ b/packages/plugins/plugin-diff/src/types.ts
@@ -16,8 +16,6 @@ export interface DiffState {
 
 /// Configuration options for the diff plugin.
 export interface DiffConfig {
-  /** Lock document editing during diff review (default: true) */
-  lockOnReview: boolean
   /** Map of node type names to attribute keys to ignore when diffing */
   ignoreAttrs: Record<string, string[]>
 }

--- a/packages/plugins/plugin-streaming/src/streaming-commands.ts
+++ b/packages/plugins/plugin-streaming/src/streaming-commands.ts
@@ -117,8 +117,6 @@ export const endStreamingCmd = $command('EndStreaming', (ctx) => {
       } satisfies StreamingAction)
 
       // Diff review handoff: restore original doc, then start diff review.
-      // Note: when lockDuringStreaming is disabled, restoring originalDoc
-      // discards any concurrent edits made during the streaming session.
       if (diffReview && result.newDoc) {
         const finalDoc = tr.doc
 
@@ -170,8 +168,6 @@ export const abortStreamingCmd = $command('AbortStreaming', (ctx) => {
         tr = result.tr
       } else {
         // Restore original document (both insert and replace modes).
-        // Note: when lockDuringStreaming is disabled, this discards any
-        // concurrent edits made during the streaming session.
         tr = tr.replace(
           0,
           state.doc.content.size,

--- a/packages/plugins/plugin-streaming/src/streaming-config.ts
+++ b/packages/plugins/plugin-streaming/src/streaming-config.ts
@@ -8,7 +8,6 @@ import { withMeta } from './__internal__/with-meta'
 export const streamingConfig = $ctx<StreamingConfig, 'streamingConfig'>(
   {
     throttleMs: 100,
-    lockDuringStreaming: true,
     scrollFollow: true,
     diffReviewOnEnd: false,
     ignoreAttrs: { heading: ['id'] },

--- a/packages/plugins/plugin-streaming/src/streaming-plugin.ts
+++ b/packages/plugins/plugin-streaming/src/streaming-plugin.ts
@@ -72,8 +72,7 @@ export const streamingPlugin = $prose((ctx) => {
         let state = applyStreamingAction(value, action)
 
         // Map insert positions through transaction mapping when the doc
-        // changes from a non-streaming transaction (e.g. collaborative edits
-        // when lockDuringStreaming is disabled).
+        // changes from a non-streaming transaction (e.g. collaborative edits).
         if (
           state?.active &&
           state.insertPos != null &&
@@ -94,8 +93,6 @@ export const streamingPlugin = $prose((ctx) => {
       },
     },
     filterTransaction(tr, editorState) {
-      if (!config.lockDuringStreaming) return true
-
       const state = streamingPluginKey.getState(editorState)
       if (!state?.active) return true
 

--- a/packages/plugins/plugin-streaming/src/streaming-plugin.ts
+++ b/packages/plugins/plugin-streaming/src/streaming-plugin.ts
@@ -69,27 +69,7 @@ export const streamingPlugin = $prose((ctx) => {
         const action = tr.getMeta(streamingPluginKey) as
           | StreamingAction
           | undefined
-        let state = applyStreamingAction(value, action)
-
-        // Map insert positions through transaction mapping when the doc
-        // changes from a non-streaming transaction (e.g. collaborative edits).
-        if (
-          state?.active &&
-          state.insertPos != null &&
-          tr.docChanged &&
-          !action
-        ) {
-          state = {
-            ...state,
-            insertPos: tr.mapping.map(state.insertPos),
-            insertEndPos:
-              state.insertEndPos != null
-                ? tr.mapping.map(state.insertEndPos)
-                : null,
-          }
-        }
-
-        return state
+        return applyStreamingAction(value, action)
       },
     },
     filterTransaction(tr, editorState) {

--- a/packages/plugins/plugin-streaming/src/types.ts
+++ b/packages/plugins/plugin-streaming/src/types.ts
@@ -38,10 +38,6 @@ export type InsertStrategyResolver = (resolved: ResolvedPos) => InsertStrategy
 export interface StreamingConfig {
   /// Throttle interval for parse+diff+apply in ms (default: 100).
   throttleMs: number
-  /// Lock editing during streaming (default: true).
-  /// When disabled, concurrent edits are allowed but abort/diff-review
-  /// will restore the original document snapshot, discarding those edits.
-  lockDuringStreaming: boolean
   /// Auto-scroll to follow streaming content (default: true).
   scrollFollow: boolean
   /// Enter diff review mode after streaming ends (default: false).


### PR DESCRIPTION
- [x] I read the contributing guide
- [x] I agree to follow the code of conduct

## Summary

Remove three config options that are broken and can't be fixed without fundamental architecture changes:

- **`DiffConfig.lockOnReview`** — when `false`, user edits during diff review shift document positions but `newDoc` stays fixed. Accept/reject commands use the shifted positions to index into the fixed `newDoc`, causing content corruption. Editing during diff review was never safe; the config option only hid the locking that prevented it.

- **`DiffComponentConfig.classPrefix`** — all Crepe themes hardcode `milkdown-diff-*` CSS selectors. Changing the prefix silently breaks every theme with no workaround. Replaced with a hardcoded `CLASS_PREFIX` module constant.

- **`StreamingConfig.lockDuringStreaming`** — when `false`, user edits are overwritten by the next streaming flush (which does a full diff+replace against the buffer). Abort restores the original doc snapshot, discarding all concurrent edits. The comments already acknowledged this: "abort/diff-review will restore the original document snapshot, discarding those edits".

Also cleaned up their passthrough in `AIDiffConfig` and updated docs examples.

## How did you test this change?

- Ran vitest suites in `packages/plugins/plugin-diff`, `packages/plugins/plugin-streaming`, and `packages/components`.
- Ran the Playwright suite in `e2e` — 172 tests pass.
- Verified `pnpm -F @milkdown/docs run build` passes (crepe, plugin-diff, plugin-streaming all build).
- Typechecked all four affected packages.